### PR TITLE
Allow listening on 0.0.0.0:x

### DIFF
--- a/vnet/README.md
+++ b/vnet/README.md
@@ -201,7 +201,7 @@ func (a *Agent) listenUDP(...) error {
 |net.Listen()|a.net.Listen()|(TODO)|
 |net.ListenTCP()|(not supported)|(Listen() would be recommended)|
 |net.Dial()|a.net.Dial()||
-|net.DialUDP()|(not supported)|Use Dial()|
+|net.DialUDP()|a.net.DialUDP()||
 |net.DialTCP()|(not supported)||
 |net.Interface|vnet.Interface||
 |net.PacketConn|(use it as-is)||
@@ -218,14 +218,7 @@ func (a *Agent) listenUDP(...) error {
 ## TODO / Next Step
 * Implement TCP (TCPConn, Listen)
 * Support of IPv6
-* Convert pion/stun to use vnet (we will need to implement STUN server also)
-* Convert pion/ice to use vnet
-* Convert all other pion packages that use net package to vnet
 * Write a bunch of examples for building virtual networks.
-  - WAN only
-  - WAN + n x LAN(w/ NAT)
-  - Two Nets (NICs) under the same LAN(NAT)
-  - Set up various types of NAT (various cone NAT, symmetric NAT, etc)
 * Add network impairment features (on Router)
   - Introduce lantecy / jitter
   - Packet filtering handler (allow selectively drop packets, etc.)

--- a/vnet/conn.go
+++ b/vnet/conn.go
@@ -40,13 +40,14 @@ type UDPConn struct {
 	readTimer *time.Timer
 }
 
-func newUDPConn(addr *net.UDPAddr, obs connObserver) (*UDPConn, error) {
+func newUDPConn(locAddr, remAddr *net.UDPAddr, obs connObserver) (*UDPConn, error) {
 	if obs == nil {
 		return nil, fmt.Errorf("obs cannot be nil")
 	}
 
 	return &UDPConn{
-		locAddr:   addr,
+		locAddr:   locAddr,
+		remAddr:   remAddr,
 		obs:       obs,
 		readCh:    make(chan Chunk, maxReadQueueSize),
 		closeCh:   make(chan struct{}),

--- a/vnet/conn_map.go
+++ b/vnet/conn_map.go
@@ -27,10 +27,7 @@ func (m *udpConnMap) insert(conn *UDPConn) error {
 
 		for _, conn := range conns {
 			laddr := conn.LocalAddr().(*net.UDPAddr)
-			if laddr.IP.IsUnspecified() {
-				return fmt.Errorf("address already in use")
-			}
-			if laddr.IP.Equal(udpAddr.IP) {
+			if laddr.IP.IsUnspecified() || laddr.IP.Equal(udpAddr.IP) {
 				return fmt.Errorf("address already in use")
 			}
 		}
@@ -60,12 +57,8 @@ func (m *udpConnMap) find(addr net.Addr) (*UDPConn, bool) {
 
 		for _, conn := range conns {
 			laddr := conn.LocalAddr().(*net.UDPAddr)
-			if laddr.IP.IsUnspecified() {
+			if laddr.IP.IsUnspecified() || laddr.IP.Equal(udpAddr.IP) {
 				return conn, ok
-			}
-
-			if laddr.IP.Equal(udpAddr.IP) {
-				return conn, true
 			}
 		}
 	}

--- a/vnet/conn_map.go
+++ b/vnet/conn_map.go
@@ -1,0 +1,135 @@
+package vnet
+
+import (
+	"fmt"
+	"net"
+)
+
+type udpConnMap struct {
+	portMap map[int][]*UDPConn
+}
+
+func newUDPConnMap() *udpConnMap {
+	return &udpConnMap{
+		portMap: map[int][]*UDPConn{},
+	}
+}
+
+func (m *udpConnMap) insert(conn *UDPConn) error {
+	udpAddr := conn.LocalAddr().(*net.UDPAddr)
+
+	// check if the port has a listener
+	conns, ok := m.portMap[udpAddr.Port]
+	if ok {
+		if udpAddr.IP.IsUnspecified() {
+			return fmt.Errorf("address already in use")
+		}
+
+		for _, conn := range conns {
+			laddr := conn.LocalAddr().(*net.UDPAddr)
+			if laddr.IP.IsUnspecified() {
+				return fmt.Errorf("address already in use")
+			}
+			if laddr.IP.Equal(udpAddr.IP) {
+				return fmt.Errorf("address already in use")
+			}
+		}
+
+		conns = append(conns, conn)
+	} else {
+		conns = []*UDPConn{conn}
+	}
+
+	m.portMap[udpAddr.Port] = conns
+	return nil
+}
+
+func (m *udpConnMap) find(addr net.Addr) (*UDPConn, bool) {
+	udpAddr := addr.(*net.UDPAddr)
+
+	if conns, ok := m.portMap[udpAddr.Port]; ok {
+		if udpAddr.IP.IsUnspecified() {
+			// pick the first one appears in the iteration
+			if len(conns) == 0 {
+				// This can't happen!
+				delete(m.portMap, udpAddr.Port)
+				return nil, false
+			}
+			return conns[0], true
+		}
+
+		for _, conn := range conns {
+			laddr := conn.LocalAddr().(*net.UDPAddr)
+			if laddr.IP.IsUnspecified() {
+				return conn, ok
+			}
+
+			if laddr.IP.Equal(udpAddr.IP) {
+				return conn, true
+			}
+		}
+	}
+
+	return nil, false
+}
+
+func (m *udpConnMap) delete(addr net.Addr) error {
+	udpAddr := addr.(*net.UDPAddr)
+
+	conns, ok := m.portMap[udpAddr.Port]
+	if !ok {
+		return fmt.Errorf("no such UDPConn")
+	}
+
+	if udpAddr.IP.IsUnspecified() {
+		// remove all from this port
+		delete(m.portMap, udpAddr.Port)
+		return nil
+	}
+
+	newConns := []*UDPConn{}
+
+	for _, conn := range conns {
+		laddr := conn.LocalAddr().(*net.UDPAddr)
+		if laddr.IP.IsUnspecified() {
+			// This can't happen!
+			return fmt.Errorf("cannot remove an unspecified IP by the specified IP")
+		}
+
+		if laddr.IP.Equal(udpAddr.IP) {
+			continue
+		}
+
+		newConns = append(newConns, conn)
+	}
+
+	if len(newConns) == 0 {
+		delete(m.portMap, udpAddr.Port)
+	} else {
+		m.portMap[udpAddr.Port] = newConns
+	}
+
+	return nil
+}
+
+// size returns the number of UDPConns (UDP listeners)
+func (m *udpConnMap) size() int {
+	n := 0
+	for _, conns := range m.portMap {
+		n += len(conns)
+	}
+
+	return n
+}
+
+// patterns
+// * insert 0.0.0.0:1234
+// * find 0.0.0.0:1234
+// * find 192.168.0.1:1234
+//   - find 192.168.0.1:1234
+//   - find 0.0.0.0
+// * delete 0.0.0.0:1234
+// * delete 192.168.0.1:1234
+// question
+// * insert 192.168.0.1:1234 when 0.0.0.0 already exists => error
+// * insert 0.0.0.0 when 192.168.0.1 already exists => error

--- a/vnet/conn_map_test.go
+++ b/vnet/conn_map_test.go
@@ -31,7 +31,7 @@ func TestUDPConnMap(t *testing.T) {
 		connIn, err := newUDPConn(&net.UDPAddr{
 			IP:   net.ParseIP("127.0.0.1"),
 			Port: 1234,
-		}, obs)
+		}, nil, obs)
 		assert.NoError(t, err, "should succeed")
 
 		err = connMap.insert(connIn)
@@ -57,7 +57,7 @@ func TestUDPConnMap(t *testing.T) {
 		connIn, err := newUDPConn(&net.UDPAddr{
 			IP:   net.ParseIP("0.0.0.0"),
 			Port: 1234,
-		}, obs)
+		}, nil, obs)
 		assert.NoError(t, err, "should succeed")
 
 		err = connMap.insert(connIn)
@@ -82,7 +82,7 @@ func TestUDPConnMap(t *testing.T) {
 		connIn, err := newUDPConn(&net.UDPAddr{
 			IP:   net.ParseIP("0.0.0.0"),
 			Port: 1234,
-		}, obs)
+		}, nil, obs)
 		assert.NoError(t, err, "should succeed")
 
 		err = connMap.insert(connIn)
@@ -104,7 +104,7 @@ func TestUDPConnMap(t *testing.T) {
 		connIn1, err := newUDPConn(&net.UDPAddr{
 			IP:   net.ParseIP("10.1.2.1"),
 			Port: 5678,
-		}, obs)
+		}, nil, obs)
 		assert.NoError(t, err, "should succeed")
 		err = connMap.insert(connIn1)
 		assert.NoError(t, err, "should succeed")
@@ -112,7 +112,7 @@ func TestUDPConnMap(t *testing.T) {
 		connIn2, err := newUDPConn(&net.UDPAddr{
 			IP:   net.ParseIP("10.1.2.2"),
 			Port: 5678,
-		}, obs)
+		}, nil, obs)
 		assert.NoError(t, err, "should succeed")
 		err = connMap.insert(connIn2)
 		assert.NoError(t, err, "should succeed")
@@ -141,7 +141,7 @@ func TestUDPConnMap(t *testing.T) {
 		connIn1, err := newUDPConn(&net.UDPAddr{
 			IP:   net.ParseIP("10.1.2.1"),
 			Port: 5678,
-		}, obs)
+		}, nil, obs)
 		assert.NoError(t, err, "should succeed")
 		err = connMap.insert(connIn1)
 		assert.NoError(t, err, "should succeed")
@@ -149,7 +149,7 @@ func TestUDPConnMap(t *testing.T) {
 		connIn2, err := newUDPConn(&net.UDPAddr{
 			IP:   net.ParseIP("0.0.0.0"),
 			Port: 5678,
-		}, obs)
+		}, nil, obs)
 		assert.NoError(t, err, "should succeed")
 
 		err = connMap.insert(connIn2)
@@ -163,7 +163,7 @@ func TestUDPConnMap(t *testing.T) {
 		connIn1, err := newUDPConn(&net.UDPAddr{
 			IP:   net.ParseIP("0.0.0.0"),
 			Port: 5678,
-		}, obs)
+		}, nil, obs)
 		assert.NoError(t, err, "should succeed")
 		err = connMap.insert(connIn1)
 		assert.NoError(t, err, "should succeed")
@@ -171,7 +171,7 @@ func TestUDPConnMap(t *testing.T) {
 		connIn2, err := newUDPConn(&net.UDPAddr{
 			IP:   net.ParseIP("192.168.0.1"),
 			Port: 5678,
-		}, obs)
+		}, nil, obs)
 		assert.NoError(t, err, "should succeed")
 
 		err = connMap.insert(connIn2)
@@ -185,7 +185,7 @@ func TestUDPConnMap(t *testing.T) {
 		connIn1, err := newUDPConn(&net.UDPAddr{
 			IP:   net.ParseIP("192.168.0.1"),
 			Port: 5678,
-		}, obs)
+		}, nil, obs)
 		assert.NoError(t, err, "should succeed")
 		err = connMap.insert(connIn1)
 		assert.NoError(t, err, "should succeed")
@@ -193,7 +193,7 @@ func TestUDPConnMap(t *testing.T) {
 		connIn2, err := newUDPConn(&net.UDPAddr{
 			IP:   net.ParseIP("192.168.0.1"),
 			Port: 5678,
-		}, obs)
+		}, nil, obs)
 		assert.NoError(t, err, "should succeed")
 
 		err = connMap.insert(connIn2)
@@ -207,7 +207,7 @@ func TestUDPConnMap(t *testing.T) {
 		connIn, err := newUDPConn(&net.UDPAddr{
 			IP:   net.ParseIP("192.168.0.1"),
 			Port: 5678,
-		}, obs)
+		}, nil, obs)
 		assert.NoError(t, err, "should succeed")
 		err = connMap.insert(connIn)
 		assert.NoError(t, err, "should succeed")
@@ -226,7 +226,7 @@ func TestUDPConnMap(t *testing.T) {
 		connIn, err := newUDPConn(&net.UDPAddr{
 			IP:   net.ParseIP("192.168.0.1"),
 			Port: 5678,
-		}, obs)
+		}, nil, obs)
 		assert.NoError(t, err, "should succeed")
 		err = connMap.insert(connIn)
 		assert.NoError(t, err, "should succeed")
@@ -246,7 +246,7 @@ func TestUDPConnMap(t *testing.T) {
 		connIn1, err := newUDPConn(&net.UDPAddr{
 			IP:   net.ParseIP("192.168.0.1"),
 			Port: 5678,
-		}, obs)
+		}, nil, obs)
 		assert.NoError(t, err, "should succeed")
 		err = connMap.insert(connIn1)
 		assert.NoError(t, err, "should succeed")
@@ -254,7 +254,7 @@ func TestUDPConnMap(t *testing.T) {
 		connIn2, err := newUDPConn(&net.UDPAddr{
 			IP:   net.ParseIP("192.168.0.2"),
 			Port: 5678,
-		}, obs)
+		}, nil, obs)
 		assert.NoError(t, err, "should succeed")
 		err = connMap.insert(connIn2)
 		assert.NoError(t, err, "should succeed")

--- a/vnet/conn_map_test.go
+++ b/vnet/conn_map_test.go
@@ -34,7 +34,8 @@ func TestUDPConnMap(t *testing.T) {
 		}, obs)
 		assert.NoError(t, err, "should succeed")
 
-		connMap.insert(connIn)
+		err = connMap.insert(connIn)
+		assert.NoError(t, err, "should succeed")
 
 		connOut, ok := connMap.find(connIn.LocalAddr())
 		assert.True(t, ok, "should succeed")

--- a/vnet/conn_map_test.go
+++ b/vnet/conn_map_test.go
@@ -1,0 +1,267 @@
+package vnet
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type myConnObserver struct {
+}
+
+func (obs *myConnObserver) write(c Chunk) error {
+	return nil
+}
+
+func (obs *myConnObserver) onClosed(addr net.Addr) {
+}
+
+func (obs *myConnObserver) determineSourceIP(locIP, dstIP net.IP) net.IP {
+	return net.IP{}
+}
+
+func TestUDPConnMap(t *testing.T) {
+	//log := logging.NewDefaultLoggerFactory().NewLogger("test")
+
+	t.Run("insert an UDPConn and remove it", func(t *testing.T) {
+		connMap := newUDPConnMap()
+
+		obs := &myConnObserver{}
+		connIn, err := newUDPConn(&net.UDPAddr{
+			IP:   net.ParseIP("127.0.0.1"),
+			Port: 1234,
+		}, obs)
+		assert.NoError(t, err, "should succeed")
+
+		connMap.insert(connIn)
+
+		connOut, ok := connMap.find(connIn.LocalAddr())
+		assert.True(t, ok, "should succeed")
+		assert.Equal(t, connIn, connOut, "should match")
+		assert.Equal(t, 1, len(connMap.portMap), "should match")
+
+		err = connMap.delete(connIn.LocalAddr())
+		assert.NoError(t, err, "should succeed")
+		assert.Equal(t, 0, len(connMap.portMap), "should match")
+
+		err = connMap.delete(connIn.LocalAddr())
+		assert.Error(t, err, "should fail")
+	})
+
+	t.Run("insert an UDPConn on 0.0.0.0 and remove it", func(t *testing.T) {
+		connMap := newUDPConnMap()
+
+		obs := &myConnObserver{}
+		connIn, err := newUDPConn(&net.UDPAddr{
+			IP:   net.ParseIP("0.0.0.0"),
+			Port: 1234,
+		}, obs)
+		assert.NoError(t, err, "should succeed")
+
+		err = connMap.insert(connIn)
+		assert.NoError(t, err, "should succeed")
+
+		connOut, ok := connMap.find(connIn.LocalAddr())
+		assert.True(t, ok, "should succeed")
+		assert.Equal(t, connIn, connOut, "should match")
+		assert.Equal(t, 1, len(connMap.portMap), "should match")
+
+		err = connMap.delete(connIn.LocalAddr())
+		assert.NoError(t, err, "should succeed")
+
+		err = connMap.delete(connIn.LocalAddr())
+		assert.Error(t, err, "should fail")
+	})
+
+	t.Run("find UDPConn on 0.0.0.0 by specified IP", func(t *testing.T) {
+		connMap := newUDPConnMap()
+
+		obs := &myConnObserver{}
+		connIn, err := newUDPConn(&net.UDPAddr{
+			IP:   net.ParseIP("0.0.0.0"),
+			Port: 1234,
+		}, obs)
+		assert.NoError(t, err, "should succeed")
+
+		err = connMap.insert(connIn)
+		assert.NoError(t, err, "should succeed")
+
+		connOut, ok := connMap.find(&net.UDPAddr{
+			IP:   net.ParseIP("192.168.0.1"),
+			Port: 1234,
+		})
+		assert.True(t, ok, "should succeed")
+		assert.Equal(t, connIn, connOut, "should match")
+		assert.Equal(t, 1, len(connMap.portMap), "should match")
+	})
+
+	t.Run("insert many IPs with the same port", func(t *testing.T) {
+		connMap := newUDPConnMap()
+
+		obs := &myConnObserver{}
+		connIn1, err := newUDPConn(&net.UDPAddr{
+			IP:   net.ParseIP("10.1.2.1"),
+			Port: 5678,
+		}, obs)
+		assert.NoError(t, err, "should succeed")
+		err = connMap.insert(connIn1)
+		assert.NoError(t, err, "should succeed")
+
+		connIn2, err := newUDPConn(&net.UDPAddr{
+			IP:   net.ParseIP("10.1.2.2"),
+			Port: 5678,
+		}, obs)
+		assert.NoError(t, err, "should succeed")
+		err = connMap.insert(connIn2)
+		assert.NoError(t, err, "should succeed")
+
+		connOut1, ok := connMap.find(&net.UDPAddr{
+			IP:   net.ParseIP("10.1.2.1"),
+			Port: 5678,
+		})
+		assert.True(t, ok, "should succeed")
+		assert.Equal(t, connIn1, connOut1, "should match")
+
+		connOut2, ok := connMap.find(&net.UDPAddr{
+			IP:   net.ParseIP("10.1.2.2"),
+			Port: 5678,
+		})
+		assert.True(t, ok, "should succeed")
+		assert.Equal(t, connIn2, connOut2, "should match")
+
+		assert.Equal(t, 1, len(connMap.portMap), "should match")
+	})
+
+	t.Run("already in-use when inserting 0.0.0.0", func(t *testing.T) {
+		connMap := newUDPConnMap()
+
+		obs := &myConnObserver{}
+		connIn1, err := newUDPConn(&net.UDPAddr{
+			IP:   net.ParseIP("10.1.2.1"),
+			Port: 5678,
+		}, obs)
+		assert.NoError(t, err, "should succeed")
+		err = connMap.insert(connIn1)
+		assert.NoError(t, err, "should succeed")
+
+		connIn2, err := newUDPConn(&net.UDPAddr{
+			IP:   net.ParseIP("0.0.0.0"),
+			Port: 5678,
+		}, obs)
+		assert.NoError(t, err, "should succeed")
+
+		err = connMap.insert(connIn2)
+		assert.Error(t, err, "should fail")
+	})
+
+	t.Run("already in-use when inserting a specified IP", func(t *testing.T) {
+		connMap := newUDPConnMap()
+
+		obs := &myConnObserver{}
+		connIn1, err := newUDPConn(&net.UDPAddr{
+			IP:   net.ParseIP("0.0.0.0"),
+			Port: 5678,
+		}, obs)
+		assert.NoError(t, err, "should succeed")
+		err = connMap.insert(connIn1)
+		assert.NoError(t, err, "should succeed")
+
+		connIn2, err := newUDPConn(&net.UDPAddr{
+			IP:   net.ParseIP("192.168.0.1"),
+			Port: 5678,
+		}, obs)
+		assert.NoError(t, err, "should succeed")
+
+		err = connMap.insert(connIn2)
+		assert.Error(t, err, "should fail")
+	})
+
+	t.Run("already in-use when inserting the same specified IP", func(t *testing.T) {
+		connMap := newUDPConnMap()
+
+		obs := &myConnObserver{}
+		connIn1, err := newUDPConn(&net.UDPAddr{
+			IP:   net.ParseIP("192.168.0.1"),
+			Port: 5678,
+		}, obs)
+		assert.NoError(t, err, "should succeed")
+		err = connMap.insert(connIn1)
+		assert.NoError(t, err, "should succeed")
+
+		connIn2, err := newUDPConn(&net.UDPAddr{
+			IP:   net.ParseIP("192.168.0.1"),
+			Port: 5678,
+		}, obs)
+		assert.NoError(t, err, "should succeed")
+
+		err = connMap.insert(connIn2)
+		assert.Error(t, err, "should fail")
+	})
+
+	t.Run("find failure 1", func(t *testing.T) {
+		connMap := newUDPConnMap()
+
+		obs := &myConnObserver{}
+		connIn, err := newUDPConn(&net.UDPAddr{
+			IP:   net.ParseIP("192.168.0.1"),
+			Port: 5678,
+		}, obs)
+		assert.NoError(t, err, "should succeed")
+		err = connMap.insert(connIn)
+		assert.NoError(t, err, "should succeed")
+
+		_, ok := connMap.find(&net.UDPAddr{
+			IP:   net.ParseIP("192.168.0.2"),
+			Port: 5678,
+		})
+		assert.False(t, ok, "should fail")
+	})
+
+	t.Run("find failure 2", func(t *testing.T) {
+		connMap := newUDPConnMap()
+
+		obs := &myConnObserver{}
+		connIn, err := newUDPConn(&net.UDPAddr{
+			IP:   net.ParseIP("192.168.0.1"),
+			Port: 5678,
+		}, obs)
+		assert.NoError(t, err, "should succeed")
+		err = connMap.insert(connIn)
+		assert.NoError(t, err, "should succeed")
+
+		_, ok := connMap.find(&net.UDPAddr{
+			IP:   net.ParseIP("192.168.0.1"),
+			Port: 1234,
+		})
+		assert.False(t, ok, "should fail")
+	})
+
+	t.Run("insert two UDPConns on the same port, then remove them", func(t *testing.T) {
+		connMap := newUDPConnMap()
+
+		obs := &myConnObserver{}
+
+		connIn1, err := newUDPConn(&net.UDPAddr{
+			IP:   net.ParseIP("192.168.0.1"),
+			Port: 5678,
+		}, obs)
+		assert.NoError(t, err, "should succeed")
+		err = connMap.insert(connIn1)
+		assert.NoError(t, err, "should succeed")
+
+		connIn2, err := newUDPConn(&net.UDPAddr{
+			IP:   net.ParseIP("192.168.0.2"),
+			Port: 5678,
+		}, obs)
+		assert.NoError(t, err, "should succeed")
+		err = connMap.insert(connIn2)
+		assert.NoError(t, err, "should succeed")
+
+		err = connMap.delete(connIn1.LocalAddr())
+		assert.NoError(t, err, "should succeed")
+
+		err = connMap.delete(connIn2.LocalAddr())
+		assert.NoError(t, err, "should succeed")
+	})
+}

--- a/vnet/conn_test.go
+++ b/vnet/conn_test.go
@@ -64,7 +64,7 @@ func TestUDPConn(t *testing.T) {
 				atomic.AddInt32(&nClosed, 1)
 			},
 		}
-		conn, err = newUDPConn(srcAddr, obs)
+		conn, err = newUDPConn(srcAddr, nil, obs)
 		assert.NoError(t, err, "should succeed")
 
 		rcvdCh := make(chan struct{})
@@ -144,7 +144,7 @@ func TestUDPConn(t *testing.T) {
 				atomic.AddInt32(&nClosed, 1)
 			},
 		}
-		conn, err = newUDPConn(srcAddr, obs)
+		conn, err = newUDPConn(srcAddr, nil, obs)
 		assert.NoError(t, err, "should succeed")
 		conn.remAddr = dstAddr
 
@@ -202,7 +202,7 @@ func TestUDPConn(t *testing.T) {
 				atomic.AddInt32(&nClosed, 1)
 			},
 		}
-		conn, err = newUDPConn(srcAddr, obs)
+		conn, err = newUDPConn(srcAddr, nil, obs)
 		assert.NoError(t, err, "should succeed")
 
 		doneCh := make(chan struct{})

--- a/vnet/nat.go
+++ b/vnet/nat.go
@@ -25,6 +25,10 @@ const (
 	EndpointAddrPortDependent
 )
 
+const (
+	defaultNATMappingLifeTime = 30 * time.Second
+)
+
 // NATType has a set of parameters that define the behavior of NAT.
 type NATType struct {
 	MappingBehavior   EndpointDependencyType
@@ -59,8 +63,13 @@ type networkAddressTranslator struct {
 }
 
 func newNAT(config *natConfig) *networkAddressTranslator {
+	natType := config.natType
+	if natType.MappingLifeTime == 0 {
+		natType.MappingLifeTime = defaultNATMappingLifeTime
+	}
+
 	return &networkAddressTranslator{
-		natType:     config.natType,
+		natType:     natType,
 		mappedIP:    config.mappedIP,
 		outboundMap: map[string]*mapping{},
 		inboundMap:  map[string]*mapping{},

--- a/vnet/nat_test.go
+++ b/vnet/nat_test.go
@@ -14,6 +14,21 @@ import (
 // iic: inbound internal chunk
 // iec: inbound external chunk
 
+func TestNATTypeDefauts(t *testing.T) {
+	loggerFactory := logging.NewDefaultLoggerFactory()
+	nat := newNAT(&natConfig{
+		natType:       NATType{},
+		mappedIP:      "1.2.3.4",
+		loggerFactory: loggerFactory,
+	})
+
+	assert.Equal(t, EndpointIndependent, nat.natType.MappingBehavior, "should match")
+	assert.Equal(t, EndpointIndependent, nat.natType.FilteringBehavior, "should match")
+	assert.False(t, nat.natType.Hairpining, "should be false")
+	assert.False(t, nat.natType.PortPreservation, "should be false")
+	assert.Equal(t, defaultNATMappingLifeTime, nat.natType.MappingLifeTime, "should be false")
+}
+
 func TestNATMappingBehavior(t *testing.T) {
 	loggerFactory := logging.NewDefaultLoggerFactory()
 	log := loggerFactory.NewLogger("test")

--- a/vnet/net.go
+++ b/vnet/net.go
@@ -156,14 +156,12 @@ func (v *vNet) _listenUDP(network string, locAddr *net.UDPAddr) (UDPPacketConn, 
 			}
 		}
 		locAddr.Port = port
-	} else {
-		if _, ok := v.udpConns.find(locAddr); ok {
-			return nil, &net.OpError{
-				Op:   "listen",
-				Net:  network,
-				Addr: locAddr,
-				Err:  fmt.Errorf("bind: address already in use"),
-			}
+	} else if _, ok := v.udpConns.find(locAddr); ok {
+		return nil, &net.OpError{
+			Op:   "listen",
+			Net:  network,
+			Addr: locAddr,
+			Err:  fmt.Errorf("bind: address already in use"),
 		}
 	}
 
@@ -311,7 +309,8 @@ func (v *vNet) write(c Chunk) error {
 
 func (v *vNet) onClosed(addr net.Addr) {
 	if addr.Network() == "udp" {
-		v.udpConns.delete(addr)
+		//nolint:errcheck
+		v.udpConns.delete(addr) // #nosec
 	}
 }
 

--- a/vnet/net_native_test.go
+++ b/vnet/net_native_test.go
@@ -1,0 +1,197 @@
+package vnet
+
+import (
+	"net"
+	"testing"
+
+	"github.com/pion/logging"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNetNative(t *testing.T) {
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+
+	t.Run("Interfaces", func(t *testing.T) {
+		nw := NewNet(nil)
+		interfaces, err := nw.Interfaces()
+		assert.NoError(t, err, "should succeed")
+		log.Debugf("interfaces: %+v\n", interfaces)
+		for _, ifc := range interfaces {
+			if ifc.Name == "lo0" {
+				_, err := ifc.Addrs()
+				assert.NoError(t, err, "should succeed")
+			}
+
+			if addrs, err := ifc.Addrs(); err == nil {
+				for _, addr := range addrs {
+					log.Debugf("[%d] %s:%s",
+						ifc.Index,
+						addr.Network(),
+						addr.String())
+				}
+			}
+		}
+	})
+
+	t.Run("ListenPacket", func(t *testing.T) {
+		nw := NewNet(nil)
+
+		conn, err := nw.ListenPacket("udp", "127.0.0.1:0")
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+
+		udpConn, ok := conn.(*net.UDPConn)
+		assert.True(t, ok, "should succeed")
+		log.Debugf("udpConn: %+v", udpConn)
+
+		laddr := conn.LocalAddr().String()
+		log.Debugf("laddr: %s", laddr)
+	})
+
+	t.Run("ListenUDP random port", func(t *testing.T) {
+		nw := NewNet(nil)
+
+		srcAddr := &net.UDPAddr{
+			IP: net.ParseIP("127.0.0.1"),
+		}
+		conn, err := nw.ListenUDP("udp", srcAddr)
+		assert.NoError(t, err, "should succeed")
+
+		laddr := conn.LocalAddr().String()
+		log.Debugf("laddr: %s", laddr)
+
+		assert.NoError(t, conn.Close(), "should succeed")
+	})
+
+	t.Run("Dial (UDP)", func(t *testing.T) {
+		nw := NewNet(nil)
+
+		conn, err := nw.Dial("udp", "127.0.0.1:1234")
+		assert.NoError(t, err, "should succeed")
+
+		laddr := conn.LocalAddr()
+		log.Debugf("laddr: %s", laddr.String())
+
+		raddr := conn.RemoteAddr()
+		log.Debugf("raddr: %s", raddr.String())
+
+		assert.Equal(t, "127.0.0.1", laddr.(*net.UDPAddr).IP.String(), "should match")
+		assert.True(t, laddr.(*net.UDPAddr).Port != 0, "should match")
+		assert.Equal(t, "127.0.0.1:1234", raddr.String(), "should match")
+		assert.NoError(t, conn.Close(), "should succeed")
+	})
+
+	t.Run("DialUDP", func(t *testing.T) {
+		nw := NewNet(nil)
+
+		locAddr := &net.UDPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 0,
+		}
+
+		remAddr := &net.UDPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 1234,
+		}
+
+		conn, err := nw.DialUDP("udp", locAddr, remAddr)
+		assert.NoError(t, err, "should succeed")
+
+		laddr := conn.LocalAddr()
+		log.Debugf("laddr: %s", laddr.String())
+
+		raddr := conn.RemoteAddr()
+		log.Debugf("raddr: %s", raddr.String())
+
+		assert.Equal(t, "127.0.0.1", laddr.(*net.UDPAddr).IP.String(), "should match")
+		assert.True(t, laddr.(*net.UDPAddr).Port != 0, "should match")
+		assert.Equal(t, "127.0.0.1:1234", raddr.String(), "should match")
+		assert.NoError(t, conn.Close(), "should succeed")
+	})
+
+	t.Run("UDPLoopback", func(t *testing.T) {
+		nw := NewNet(nil)
+
+		conn, err := nw.ListenPacket("udp", "127.0.0.1:0")
+		assert.NoError(t, err, "should succeed")
+		laddr := conn.LocalAddr()
+		msg := "PING!"
+		n, err := conn.WriteTo([]byte(msg), laddr)
+		assert.NoError(t, err, "should succeed")
+		assert.Equal(t, len(msg), n, "should match")
+
+		buf := make([]byte, 1000)
+		n, addr, err := conn.ReadFrom(buf)
+		assert.NoError(t, err, "should succeed")
+		assert.Equal(t, len(msg), n, "should match")
+		assert.Equal(t, msg, string(buf[:n]), "should match")
+		assert.Equal(t, laddr.(*net.UDPAddr).String(), addr.(*net.UDPAddr).String(), "should match")
+		assert.NoError(t, conn.Close(), "should succeed")
+	})
+
+	t.Run("Dialer", func(t *testing.T) {
+		nw := NewNet(nil)
+
+		dialer := nw.CreateDialer(&net.Dialer{
+			LocalAddr: &net.UDPAddr{
+				IP:   net.ParseIP("127.0.0.1"),
+				Port: 0,
+			},
+		})
+
+		conn, err := dialer.Dial("udp", "127.0.0.1:1234")
+		assert.NoError(t, err, "should succeed")
+
+		laddr := conn.LocalAddr()
+		log.Debugf("laddr: %s", laddr.String())
+
+		raddr := conn.RemoteAddr()
+		log.Debugf("raddr: %s", raddr.String())
+
+		assert.Equal(t, "127.0.0.1", laddr.(*net.UDPAddr).IP.String(), "should match")
+		assert.True(t, laddr.(*net.UDPAddr).Port != 0, "should match")
+		assert.Equal(t, "127.0.0.1:1234", raddr.String(), "should match")
+		assert.NoError(t, conn.Close(), "should succeed")
+	})
+
+	t.Run("Unexpected operations", func(t *testing.T) {
+		// For portability of test, find a name of loopack interface name first
+		var loName string
+		ifs, err := net.Interfaces()
+		assert.NoError(t, err, "should succeed")
+		for _, ifc := range ifs {
+			if ifc.Flags&net.FlagLoopback != 0 {
+				loName = ifc.Name
+				break
+			}
+		}
+
+		nw := NewNet(nil)
+
+		if len(loName) > 0 {
+			// InterfaceByName
+			ifc, err2 := nw.InterfaceByName(loName)
+			assert.NoError(t, err2, "should succeed")
+			assert.Equal(t, loName, ifc.Name, "should match")
+
+			// getInterface
+			_, err2 = nw.getInterface(loName)
+			assert.Error(t, err2, "should fail")
+		}
+
+		_, err = nw.InterfaceByName("foo0")
+		assert.Error(t, err, "should fail")
+
+		// setRouter
+		err = nw.setRouter(nil)
+		assert.Error(t, err, "should fail")
+
+		// onInboundChunk (shouldn't crash)
+		nw.onInboundChunk(nil)
+
+		// getStaticIP
+		ip := nw.getStaticIP()
+		assert.Nil(t, ip, "should be nil")
+	})
+}

--- a/vnet/net_test.go
+++ b/vnet/net_test.go
@@ -210,13 +210,13 @@ func TestInterfaces(t *testing.T) {
 			assert.NoError(t, err2, "should succeed")
 			log.Debugf("[%d] got port: %d", i, port)
 
-			conn, err := newUDPConn(&net.UDPAddr{
+			conn, err2 := newUDPConn(&net.UDPAddr{
 				IP:   net.ParseIP(addr),
 				Port: port,
 			}, &myConnObserver{})
-			assert.NoError(t, err, "should succeed")
-			err = nw.v.udpConns.insert(conn)
-			assert.NoError(t, err, "should succeed")
+			assert.NoError(t, err2, "should succeed")
+			err2 = nw.v.udpConns.insert(conn)
+			assert.NoError(t, err2, "should succeed")
 		}
 
 		assert.Equal(t, space, nw.v.udpConns.size(), "should match")


### PR DESCRIPTION
See issue #15 for details

I am working on adding vnet support to pion/turn.
With these fixes, I was able to pass a new test using vnet to test communciation between TURN server and client via a virtually hosted NAT.
