### PR TITLE
Allow nill laddr for ListenUDP and DialUDP

### DIFF
--- a/vnet/conn.go
+++ b/vnet/conn.go
@@ -137,8 +137,13 @@ func (c *UDPConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
 // Close closes the connection.
 // Any blocked ReadFrom or WriteTo operations will be unblocked and return errors.
 func (c *UDPConn) Close() error {
-	close(c.closeCh)
-	c.obs.onClosed(c.locAddr)
+	select {
+	case <-c.closeCh:
+		return fmt.Errorf("the UDPConn already closed")
+	default:
+		close(c.closeCh)
+		c.obs.onClosed(c.locAddr)
+	}
 	return nil
 }
 

--- a/vnet/nat.go
+++ b/vnet/nat.go
@@ -162,7 +162,7 @@ func (n *networkAddressTranslator) translateInbound(c Chunk) (Chunk, error) {
 
 		m := n.findInboundMapping(iKey)
 		if m == nil {
-			return nil, fmt.Errorf("no inbound mapping found")
+			return nil, fmt.Errorf("no inbound NAT mapping for %s", c.String())
 		}
 
 		if err := c.setDestinationAddr(m.local); err != nil {

--- a/vnet/nat_test.go
+++ b/vnet/nat_test.go
@@ -101,6 +101,7 @@ func TestNATMappingBehavior(t *testing.T) {
 		)
 
 		_, err = nat.translateInbound(iec)
+		log.Debug(err.Error())
 		assert.NotNil(t, err, "should fail (dropped)")
 
 		// packet from any addr will be accepted (full-cone)
@@ -187,6 +188,7 @@ func TestNATMappingBehavior(t *testing.T) {
 		)
 
 		_, err = nat.translateInbound(iec)
+		log.Debug(err.Error())
 		assert.NotNil(t, err, "should fail (dropped)")
 
 		// packet from any port will be accepted (restricted-cone)
@@ -217,6 +219,7 @@ func TestNATMappingBehavior(t *testing.T) {
 		)
 
 		_, err = nat.translateInbound(iec)
+		log.Debug(err.Error())
 		assert.NotNil(t, err, "should fail (dropped)")
 	})
 

--- a/vnet/net.go
+++ b/vnet/net.go
@@ -124,6 +124,14 @@ func (v *vNet) _dialUDP(network string, locAddr, remAddr *net.UDPAddr) (UDPPacke
 		return nil, fmt.Errorf("unexpected network: %s", network)
 	}
 
+	if locAddr == nil {
+		locAddr = &net.UDPAddr{
+			IP: net.IPv4zero,
+		}
+	} else if locAddr.IP == nil {
+		locAddr.IP = net.IPv4zero
+	}
+
 	// validate address. do we have that address?
 	if !v.hasIPAddr(locAddr.IP) {
 		return nil, &net.OpError{


### PR DESCRIPTION
Fixes #20

This is to align the behavior of ListenUDP() and DialUDP() methods with that of net package.
Also, improved a debug log message.