### PR TITLE
vnet: Improve log messages

### DIFF
--- a/vnet/nat.go
+++ b/vnet/nat.go
@@ -100,7 +100,6 @@ func (n *networkAddressTranslator) translateOutbound(from Chunk) (Chunk, error) 
 
 		oKey := fmt.Sprintf("udp:%s%s", from.SourceAddr().String(), filter)
 
-		n.log.Tracef("[%s] oKey: %s\n", n.name, oKey)
 		m := n.findOutboundMapping(oKey)
 		if m == nil {
 			// Create a new mapping
@@ -119,7 +118,10 @@ func (n *networkAddressTranslator) translateOutbound(from Chunk) (Chunk, error) 
 
 			iKey := fmt.Sprintf("udp:%s:%d%s", n.mappedIP, mappedPort, filter)
 
-			n.log.Tracef("[%s] iKey: %s\n", n.name, iKey)
+			n.log.Debugf("[%s] created a new NAT binding oKey=%s iKey=%s\n",
+				n.name,
+				oKey,
+				iKey)
 			n.inboundMap[iKey] = m
 		}
 
@@ -167,7 +169,7 @@ func (n *networkAddressTranslator) translateInbound(from Chunk) (Chunk, error) {
 
 		m := n.findInboundMapping(iKey)
 		if m == nil {
-			return nil, fmt.Errorf("no inbound NAT mapping for %s", from.String())
+			return nil, fmt.Errorf("drop %s as no NAT binding found", from.String())
 		}
 
 		if err := to.setDestinationAddr(m.local); err != nil {

--- a/vnet/router.go
+++ b/vnet/router.go
@@ -360,7 +360,9 @@ func (r *Router) onProcessChunks() error {
 
 		if r.nat.natType.Hairpining {
 			hairpinned, err := r.nat.translateInbound(toParent)
-			if err == nil {
+			if err != nil {
+				r.log.Warnf("[%s] %s", r.name, err.Error())
+			} else {
 				go func() {
 					r.push(hairpinned)
 				}()

--- a/vnet/router.go
+++ b/vnet/router.go
@@ -335,6 +335,7 @@ func (r *Router) onProcessChunks() error {
 			var nic NIC
 			if nic, ok = r.nics[dstIP.String()]; !ok {
 				// NIC not found. drop it.
+				r.log.Debugf("[%s] %s unreachable", r.name, c.String())
 				continue
 			}
 
@@ -349,6 +350,7 @@ func (r *Router) onProcessChunks() error {
 		// is this WAN?
 		if r.parent == nil {
 			// this WAN. No route for this chunk
+			r.log.Debugf("[%s] no route found for %s", r.name, c.String())
 			continue
 		}
 
@@ -358,6 +360,7 @@ func (r *Router) onProcessChunks() error {
 			return err
 		}
 
+		/* FIXME: this implementation would introduce a duplicate packet!
 		if r.nat.natType.Hairpining {
 			hairpinned, err := r.nat.translateInbound(toParent)
 			if err != nil {
@@ -368,6 +371,7 @@ func (r *Router) onProcessChunks() error {
 				}()
 			}
 		}
+		*/
 
 		r.parent.push(toParent)
 	}


### PR DESCRIPTION
During the debugging for pion/ice#46, I found the improved logs in this PR had made the debugging much easier.

* Log router names (auto-assigned, also configurable)
* Improved NAT binding-related messages (new binding, how addresses are translated, etc)
* Add a unique (base36) tag for each chunks to track how a particular chunk was routed)

## Examples:
### Router name and chunk tag
```
[router3] route udp chunk 3q 10.2.0.1:5300 => 27.1.1.1:49152
```
> `route3` is the name of the router

> `3q` is the unique tag for the chunk

### NAT binding information
```
[router3] created a new NAT binding oKey=udp:10.2.0.1:5089:1.2.3.4:5495 iKey=udp:28.1.1.1:49158:1.2.3.4:5495
[router2] translate outbound chunk from udp chunk n 192.168.0.1:5318 => 10.2.0.1:5456 to udp chunk n 27.1.1.1:49154 => 10.2.0.1:5456
[router2] translate inbound chunk from udp chunk p 1.2.3.4:3478 => 27.1.1.1:49153 to udp chunk p 1.2.3.4:3478 => 192.168.0.1:5237
```

No behavioral change in this PR.

Relates to pion/ice#46