### PR TITLE
Allow BridgeConn to be closed multiple times

### DIFF
--- a/test/bridge.go
+++ b/test/bridge.go
@@ -52,7 +52,7 @@ func (conn *bridgeConn) Close() error {
 	defer conn.mutex.Unlock()
 
 	if conn.closed {
-		return fmt.Errorf("bridge has already been closed")
+		return nil
 	}
 
 	conn.closed = true


### PR DESCRIPTION
When running pion/dtls tests we want to call `Close` on both
the Client/Server. Currently we can't do that because closing a
bridgeConn twice causes an error to be returned the second time.

Instead just return nil. This matches other Pion component behaviors
where Close is idempotent
