### PR TITLE
Limit the number crypto.rand.Read bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Woodrow Douglass](https://github.com/wdouglass) *Fix test flakiness*
 * [Luke Curley](https://github.com/kixelated)
 * [Hugo Arregui](https://github.com/hugoArregui)
+* [Atsushi Watanabe](https://github.com/at-wat)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/test/rand.go
+++ b/test/rand.go
@@ -11,8 +11,11 @@ var randomness []byte
 func init() {
 	// read 1MB of randomness
 	randomness = make([]byte, 1<<20)
-	if _, err := crand.Read(randomness); err != nil {
-		fmt.Println("Failed to initiate randomness:", err)
+	for i := 0; i < len(randomness); i += 65536 {
+		// the number of bytes of entropy is limited by 65536 on some js environment
+		if _, err := crand.Read(randomness[i : i+65536]); err != nil {
+			fmt.Println("Failed to initiate randomness:", err)
+		}
 	}
 }
 


### PR DESCRIPTION
As the number of bytes of entropy is limited by 65536
on some js environment.
