### PR TITLE
Upgrade golangci-lint to 1.19.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,12 +7,13 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - gochecknoinits
-    - gochecknoglobals
-    - goconst
-    - gocyclo
     - dupl
     - funlen
+    - gochecknoglobals
+    - gochecknoinits
+    - goconst
+    - gocyclo
+    - godox
 
 issues:
   exclude-use-default: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ notifications:
     secure: IYjXoe03KykZ3v4GgUwGzfWRepO5DnJdxB87lSQ2IMsF6PBFSc3CaOX3GUclHIlzTdchR+PHj1jtEZZVSkgfp9amZBCcqbJTBOPG1YA6hxOvTpgeWIttMH0cmMxSCuCa4RfkuRH2+UXbjREMJ3ENau2CTMKReyW4Jddh9dREZohVmYuqN6uuBqCndYpt3Lm1Hv+T+vqxwTDdE/q0hwGMiwgvQm7N3K397e1q1mg+o4tMGwqyUIPnEPjaSKcEuOBa8Rqyl96nn+HGZK0zvNqUOxlzeRMM0VBcxe2s+zY/SuLj4OwNl1zEmIfY6Qj70t2cmT3xJvJprB4pCwR7q78b4lfpNu6rqCJPIZG/qDFT+XSuhDCmLlCO/+Uhtu11pgjV8UMNLTKJth+7hurH7oLNb7jYk9VYsiKhs41LICyDjJNzS5yPatF5xj0HOujb6Uh/pfI+9a+IpPSeXv1gBo8H3oWa6TfRhuTUS3Jc48p/jriZmgWgbKa1HKTaY9ENvAdZFfxJdrRg3Y4SKnjZcAPw7ijRIx1oaM3rHYbOTm/dj4ggho7EgTO3k8toQ5PKohrbBG5RERqHJvC47SXDt0fEjeGnAfN7Xtj0Pq8YyaFIj7CmCCGoI//2sWkK3AmjnwIuW0hUMsL3GsED+p0lsu6FX9wysJwy2Z2mTfIX/CXmB6w=
 
 before_script:
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.18.0
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.19.1
 
 script:
   - golangci-lint run ./...

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Woodrow Douglass](https://github.com/wdouglass) *Fix test flakiness*
 * [Luke Curley](https://github.com/kixelated)
 * [Hugo Arregui](https://github.com/hugoArregui)
+* [Atsushi Watanabe](https://github.com/at-wat)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/packetio/buffer.go
+++ b/packetio/buffer.go
@@ -1,3 +1,4 @@
+// Package packetio provides packet buffer
 package packetio
 
 import (

--- a/test/bridge_test.go
+++ b/test/bridge_test.go
@@ -10,7 +10,6 @@ import (
 func closeBridge(br *Bridge) error {
 	if err := br.conn0.Close(); err != nil {
 		return err
-
 	}
 
 	return br.conn1.Close()

--- a/test/stress.go
+++ b/test/stress.go
@@ -65,13 +65,11 @@ func StressDuplex(ca io.ReadWriter, cb io.ReadWriter, opt Options) error {
 	go func() {
 		defer wg.Done()
 		errCh <- Stress(ca, cb, opt)
-
 	}()
 
 	go func() {
 		defer wg.Done()
 		errCh <- Stress(cb, ca, opt)
-
 	}()
 
 	go func() {

--- a/test/util.go
+++ b/test/util.go
@@ -38,7 +38,6 @@ func CheckRoutines(t *testing.T) func() {
 			}
 			try++
 		}
-
 	}
 
 	tryLoop("Unexpected routines on test startup")

--- a/vnet/router_test.go
+++ b/vnet/router_test.go
@@ -422,7 +422,6 @@ func TestRouterOneChild(t *testing.T) {
 		err = wan.Stop()
 		assert.Nil(t, err, "should succeed")
 	})
-
 }
 
 func TestRouterStaticIPs(t *testing.T) {
@@ -492,7 +491,6 @@ func TestRouterStaticIPs(t *testing.T) {
 			locIP, ok := lan.staticLocalIPs[extIPStr]
 			assert.True(t, ok, "should have the external IP")
 			assert.Equal(t, localIPs[i], locIP.String(), "should match")
-
 		}
 
 		// bad local IP

--- a/vnet/stress_test.go
+++ b/vnet/stress_test.go
@@ -190,7 +190,5 @@ func TestStressTestUDP(t *testing.T) {
 
 		err = conn0.Close()
 		assert.NoError(t, err, "should succeed")
-
 	})
-
 }

--- a/vnet/vnet.go
+++ b/vnet/vnet.go
@@ -1,0 +1,2 @@
+// Package vnet provides a virtual network layer for pion
+package vnet


### PR DESCRIPTION
Fix whitespace and stylecheck error.
Disable godox.

preparing pion/.goassets#4