### PR TITLE
Support WASM build/test

### DIFF
--- a/vnet/net_native_test.go
+++ b/vnet/net_native_test.go
@@ -1,3 +1,5 @@
+// +build !js
+
 package vnet
 
 import (


### PR DESCRIPTION
Some tests using net.Conn connection are disabled for now
as it is not fully supported by WASM MVP stage.

preparation for https://github.com/pion/.goassets/pull/4