### PR TITLE
Fix TestNetNative on Debian

### DIFF
--- a/vnet/net_native_test.go
+++ b/vnet/net_native_test.go
@@ -43,7 +43,7 @@ func TestNetNative(t *testing.T) {
 		if !assert.NoError(t, err, "should succeed") {
 			return
 		}
-		assert.Equal(t, "127.0.0.1", udpAddr.IP.String(), "should match")
+		assert.Contains(t, []string{"127.0.0.1", "127.0.1.1"}, udpAddr.IP.String(), "should match")
 		assert.Equal(t, 1234, udpAddr.Port, "should match")
 	})
 


### PR DESCRIPTION
Debian based linux uses 127.0.1.1 as a local loopback address
in some condition of the install.

Fix #51
ref: https://github.com/pion/transport/pull/49