### PR TITLE
Support Go 1.14 WASM

### DIFF
--- a/test/util.go
+++ b/test/util.go
@@ -29,6 +29,7 @@ func CheckRoutines(t *testing.T) func() {
 		ticker := time.NewTicker(200 * time.Millisecond)
 		defer ticker.Stop()
 		for range ticker.C {
+			runtime.GC()
 			routines := getRoutines()
 			if len(routines) == 0 {
 				return
@@ -56,6 +57,7 @@ func filterRoutines(routines []string) []string {
 	result := []string{}
 	for _, stack := range routines {
 		if stack == "" || // Empty
+			filterRoutineWASM(stack) || // WASM specific exception
 			strings.Contains(stack, "testing.Main(") || // Tests
 			strings.Contains(stack, "testing.(*T).Run(") || // Test run
 			strings.Contains(stack, "test.getRoutines(") { // This routine

--- a/test/util_nowasm.go
+++ b/test/util_nowasm.go
@@ -1,0 +1,7 @@
+// +build !wasm
+
+package test
+
+func filterRoutineWASM(stack string) bool {
+	return false
+}

--- a/test/util_wasm.go
+++ b/test/util_wasm.go
@@ -1,0 +1,9 @@
+package test
+
+import (
+	"strings"
+)
+
+func filterRoutineWASM(stack string) bool {
+	return strings.Contains(stack, "runtime.goexit()") // Nested t.Run on Go 1.14 WASM has this routine
+}


### PR DESCRIPTION
Nested t.Run on Go 1.14 WASM has runtime.goexit() routine at beginning.

### Reference issue
https://github.com/pion/.goassets/pull/15
https://github.com/pion/webrtc/pull/1066
