### PR TITLE
Optimise packetio.Buffer by using a circular buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Luke Curley](https://github.com/kixelated)
 * [Hugo Arregui](https://github.com/hugoArregui)
 * [Atsushi Watanabe](https://github.com/at-wat)
+* [Juliusz Chroboczek](https://github.com/jech)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/packetio/buffer.go
+++ b/packetio/buffer.go
@@ -110,12 +110,6 @@ func (b *Buffer) Read(packet []byte) (n int, err error) {
 		if len(b.packets) > 0 {
 			first := b.packets[0]
 
-			// This is a packet-based reader/writer so we can't truncate.
-			if len(first) > len(packet) {
-				b.mutex.Unlock()
-				return 0, io.ErrShortBuffer
-			}
-
 			// Remove our packet and continue.
 			b.packets = b.packets[1:]
 			b.size -= len(first)
@@ -124,6 +118,9 @@ func (b *Buffer) Read(packet []byte) (n int, err error) {
 
 			// Actually transfer the data.
 			n := copy(packet, first)
+			if len(first) > len(packet) {
+				return n, io.ErrShortBuffer
+			}
 			return n, nil
 		}
 

--- a/packetio/buffer.go
+++ b/packetio/buffer.go
@@ -2,6 +2,7 @@
 package packetio
 
 import (
+	"errors"
 	"io"
 	"sync"
 	"time"
@@ -9,28 +10,36 @@ import (
 	"github.com/pion/transport/deadline"
 )
 
+var errPacketTooBig = errors.New("packet too big")
+
 // Buffer allows writing packets to an intermediate buffer, which can then be read form.
 // This is verify similar to bytes.Buffer but avoids combining multiple writes into a single read.
 type Buffer struct {
-	mutex   sync.Mutex
-	packets [][]byte
+	mutex sync.Mutex
+
+	// this is a circular buffer.  If head <= tail, then the useful
+	// data is in the interval [head, tail[.  If tail < head, then
+	// the useful data is the union of [head, len[ and [0, tail[.
+	// In order to avoid ambiguity when head = tail, we always leave
+	// an unused byte in the buffer.
+	data       []byte
+	head, tail int
 
 	notify chan struct{}
 	subs   bool
 	closed bool
 
-	// The number of buffered packets in bytes.
-	size int
+	count                 int
+	limitCount, limitSize int
 
-	// The limit on Write in packet count and total size.
-	limitCount int
-	limitSize  int
-
-	// Read deadline timer.
 	readDeadline *deadline.Deadline
 }
 
-// NewBuffer creates a new Buffer object.
+const minSize = 2048
+const cutoffSize = 128 * 1024
+const maxSize = 4 * 1024 * 1024
+
+// NewBuffer creates a new Buffer.
 func NewBuffer() *Buffer {
 	return &Buffer{
 		notify:       make(chan struct{}),
@@ -38,52 +47,126 @@ func NewBuffer() *Buffer {
 	}
 }
 
+// available returns true if the buffer is large enough to fit a packet
+// of the given size, taking overhead into account.
+func (b *Buffer) available(size int) bool {
+	available := b.head - b.tail
+	if available <= 0 {
+		available += len(b.data)
+	}
+	// we interpret head=tail as empty, so always keep a byte free
+	if size+2+1 > available {
+		return false
+	}
+
+	return true
+}
+
+// grow increases the size of the buffer.  If it returns nil, then the
+// buffer has been grown.  It returns ErrFull if hits a limit.
+func (b *Buffer) grow() error {
+	var newsize int
+	if len(b.data) < cutoffSize {
+		newsize = 2 * len(b.data)
+	} else {
+		newsize = 5 * len(b.data) / 4
+	}
+	if newsize < minSize {
+		newsize = minSize
+	}
+	if newsize > maxSize {
+		newsize = maxSize
+	}
+
+	// one byte slack
+	if b.limitSize > 0 && newsize > b.limitSize+1 {
+		newsize = b.limitSize + 1
+	}
+
+	if newsize <= len(b.data) {
+		return ErrFull
+	}
+
+	newdata := make([]byte, newsize)
+
+	var n int
+	if b.head <= b.tail {
+		// data was contiguous
+		n = copy(newdata, b.data[b.head:b.tail])
+	} else {
+		// data was discontiguous
+		n = copy(newdata, b.data[b.head:])
+		n += copy(newdata[n:], b.data[:b.tail])
+	}
+	b.head = 0
+	b.tail = n
+	b.data = newdata
+
+	return nil
+}
+
 // Write appends a copy of the packet data to the buffer.
-// If any defined limits are hit, returns ErrFull.
-func (b *Buffer) Write(packet []byte) (n int, err error) {
-	// Copy the packet before adding it.
-	packet = append([]byte{}, packet...)
+// Returns ErrFull if the packet doesn't fit.
+func (b *Buffer) Write(packet []byte) (int, error) {
+	if len(packet) >= 0x10000 {
+		return 0, errPacketTooBig
+	}
 
 	b.mutex.Lock()
 
-	// Make sure we're not closed.
 	if b.closed {
 		b.mutex.Unlock()
 		return 0, io.ErrClosedPipe
 	}
 
-	// Check if there is available capacity
-	if b.limitCount != 0 && len(b.packets)+1 > b.limitCount {
+	if (b.limitCount > 0 && b.count >= b.limitCount) ||
+		(b.limitSize > 0 && b.size()+2+len(packet) > b.limitSize) {
 		b.mutex.Unlock()
 		return 0, ErrFull
 	}
 
-	// Check if there is available capacity
-	if b.limitSize != 0 && b.size+len(packet) > b.limitSize {
-		b.mutex.Unlock()
-		return 0, ErrFull
+	// grow the buffer until the packet fits
+	for !b.available(len(packet)) {
+		err := b.grow()
+		if err != nil {
+			b.mutex.Unlock()
+			return 0, err
+		}
 	}
 
 	var notify chan struct{}
 
-	// Decide if we need to wake up any readers.
 	if b.subs {
-		// If so, close the notify channel and make a new one.
-		// This effectively behaves like a broadcast, waking up any blocked goroutines.
-		// We close after we release the lock to reduce contention.
+		// readers are waiting.  Prepare to notify, but only
+		// actually do it after we release the lock.
 		notify = b.notify
 		b.notify = make(chan struct{})
-
-		// Reset the subs marker.
 		b.subs = false
 	}
 
-	// Add the packet to the queue.
-	b.packets = append(b.packets, packet)
-	b.size += len(packet)
+	// store the length of the packet
+	b.data[b.tail] = uint8(len(packet) >> 8)
+	b.tail++
+	if b.tail >= len(b.data) {
+		b.tail = 0
+	}
+	b.data[b.tail] = uint8(len(packet))
+	b.tail++
+	if b.tail >= len(b.data) {
+		b.tail = 0
+	}
+
+	// store the packet
+	n := copy(b.data[b.tail:], packet)
+	b.tail += n
+	if b.tail >= len(b.data) {
+		// we reached the end, wrap around
+		m := copy(b.data, packet[n:])
+		b.tail = m
+	}
+	b.count++
 	b.mutex.Unlock()
 
-	// Actually close the notify channel down here.
 	if notify != nil {
 		close(notify)
 	}
@@ -106,40 +189,66 @@ func (b *Buffer) Read(packet []byte) (n int, err error) {
 	for {
 		b.mutex.Lock()
 
-		// See if there are any packets in the queue.
-		if len(b.packets) > 0 {
-			first := b.packets[0]
+		if b.head != b.tail {
+			// decode the packet size
+			n1 := b.data[b.head]
+			b.head++
+			if b.head >= len(b.data) {
+				b.head = 0
+			}
+			n2 := b.data[b.head]
+			b.head++
+			if b.head >= len(b.data) {
+				b.head = 0
+			}
+			count := int((uint16(n1) << 8) | uint16(n2))
 
-			// Remove our packet and continue.
-			b.packets = b.packets[1:]
-			b.size -= len(first)
+			// determine the number of bytes we'll actually copy
+			copied := count
+			if copied > len(packet) {
+				copied = len(packet)
+			}
+
+			// copy the data
+			if b.head+copied < len(b.data) {
+				copy(packet, b.data[b.head:b.head+copied])
+			} else {
+				k := copy(packet, b.data[b.head:])
+				copy(packet[k:], b.data[:copied-k])
+			}
+
+			// advance head, discarding any data that wasn't copied
+			b.head += count
+			if b.head >= len(b.data) {
+				b.head -= len(b.data)
+			}
+
+			if b.head == b.tail {
+				// the buffer is empty, reset to beginning
+				// in order to improve cache locality.
+				b.head = 0
+				b.tail = 0
+			}
+
+			b.count--
 
 			b.mutex.Unlock()
 
-			// Actually transfer the data.
-			n := copy(packet, first)
-			if len(first) > len(packet) {
-				return n, io.ErrShortBuffer
+			if copied < count {
+				return copied, io.ErrShortBuffer
 			}
-			return n, nil
+			return copied, nil
 		}
 
-		// Make sure the reader isn't actually closed.
-		// This is done after checking packets to fully read the buffer.
 		if b.closed {
 			b.mutex.Unlock()
 			return 0, io.EOF
 		}
 
-		// Get the current notify channel.
-		// This will be closed when there is new data available, waking us up.
 		notify := b.notify
-
-		// Set the subs marker, telling the writer we're waiting.
 		b.subs = true
 		b.mutex.Unlock()
 
-		// Wake for the broadcast.
 		select {
 		case <-b.readDeadline.Done():
 			return 0, &netError{errTimeout, true, true}
@@ -148,11 +257,9 @@ func (b *Buffer) Read(packet []byte) (n int, err error) {
 	}
 }
 
-// Close will unblock any readers and prevent future writes.
-// Data in the buffer can still be read, returning io.EOF when fully depleted.
+// Close the buffer, unblocking any pending reads.
+// Data in the buffer can still be read, Read will return io.EOF only when empty.
 func (b *Buffer) Close() (err error) {
-	// note: We don't use defer so we can close the notify channel after unlocking.
-	// This will unblock goroutines that can grab the lock immediately, instead of blocking again.
 	b.mutex.Lock()
 
 	if b.closed {
@@ -161,8 +268,8 @@ func (b *Buffer) Close() (err error) {
 	}
 
 	notify := b.notify
-
 	b.closed = true
+
 	b.mutex.Unlock()
 
 	close(notify)
@@ -174,8 +281,7 @@ func (b *Buffer) Close() (err error) {
 func (b *Buffer) Count() int {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
-
-	return len(b.packets)
+	return b.count
 }
 
 // SetLimitCount controls the maximum number of packets that can be buffered.
@@ -188,12 +294,21 @@ func (b *Buffer) SetLimitCount(limit int) {
 	b.limitCount = limit
 }
 
-// Size returns the total byte size of packets in the buffer.
+// Size returns the total byte size of packets in the buffer, including
+// a small amount of administrative overhead.
 func (b *Buffer) Size() int {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 
-	return b.size
+	return b.size()
+}
+
+func (b *Buffer) size() int {
+	size := b.tail - b.head
+	if size < 0 {
+		size += len(b.data)
+	}
+	return size
 }
 
 // SetLimitSize controls the maximum number of bytes that can be buffered.
@@ -206,8 +321,8 @@ func (b *Buffer) SetLimitSize(limit int) {
 	b.limitSize = limit
 }
 
-// SetReadDeadline sets deadline of Read operation.
-// Setting zero means no deadline.
+// SetReadDeadline sets the deadline for the Read operation.
+// Setting to zero means no deadline.
 func (b *Buffer) SetReadDeadline(t time.Time) error {
 	b.readDeadline.Set(t)
 	return nil

--- a/packetio/buffer_test.go
+++ b/packetio/buffer_test.go
@@ -311,7 +311,14 @@ func benchmarkBuffer(b *testing.B, size int64) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err := buffer.Write(packet)
+		var err error
+		for {
+			_, err = buffer.Write(packet)
+			if err != ErrFull {
+				break
+			}
+			time.Sleep(time.Microsecond)
+		}
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/packetio/buffer_test.go
+++ b/packetio/buffer_test.go
@@ -186,7 +186,7 @@ func TestBufferLimitSize(t *testing.T) {
 	assert := assert.New(t)
 
 	buffer := NewBuffer()
-	buffer.SetLimitSize(5)
+	buffer.SetLimitSize(11)
 
 	assert.Equal(0, buffer.Size())
 
@@ -194,23 +194,23 @@ func TestBufferLimitSize(t *testing.T) {
 	n, err := buffer.Write([]byte{0, 1})
 	assert.NoError(err)
 	assert.Equal(2, n)
-	assert.Equal(2, buffer.Size())
+	assert.Equal(4, buffer.Size())
 
 	n, err = buffer.Write([]byte{2, 3})
 	assert.NoError(err)
 	assert.Equal(2, n)
-	assert.Equal(4, buffer.Size())
+	assert.Equal(8, buffer.Size())
 
 	// Over capacity
 	_, err = buffer.Write([]byte{4, 5})
 	assert.Equal(ErrFull, err)
-	assert.Equal(4, buffer.Size())
+	assert.Equal(8, buffer.Size())
 
 	// Cheeky write at exact size.
 	n, err = buffer.Write([]byte{6})
 	assert.NoError(err)
 	assert.Equal(1, n)
-	assert.Equal(5, buffer.Size())
+	assert.Equal(11, buffer.Size())
 
 	// Read once
 	packet := make([]byte, 4)
@@ -218,31 +218,31 @@ func TestBufferLimitSize(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(2, n)
 	assert.Equal([]byte{0, 1}, packet[:n])
-	assert.Equal(3, buffer.Size())
+	assert.Equal(7, buffer.Size())
 
 	// Write once
 	n, err = buffer.Write([]byte{7, 8})
 	assert.NoError(err)
 	assert.Equal(2, n)
-	assert.Equal(5, buffer.Size())
+	assert.Equal(11, buffer.Size())
 
 	// Over capacity
 	_, err = buffer.Write([]byte{9, 10})
 	assert.Equal(ErrFull, err)
-	assert.Equal(5, buffer.Size())
+	assert.Equal(11, buffer.Size())
 
 	// Read everything
 	n, err = buffer.Read(packet)
 	assert.NoError(err)
 	assert.Equal(2, n)
 	assert.Equal([]byte{2, 3}, packet[:n])
-	assert.Equal(3, buffer.Size())
+	assert.Equal(7, buffer.Size())
 
 	n, err = buffer.Read(packet)
 	assert.NoError(err)
 	assert.Equal(1, n)
 	assert.Equal([]byte{6}, packet[:n])
-	assert.Equal(2, buffer.Size())
+	assert.Equal(4, buffer.Size())
 
 	n, err = buffer.Read(packet)
 	assert.NoError(err)

--- a/packetio/buffer_test.go
+++ b/packetio/buffer_test.go
@@ -270,12 +270,6 @@ func TestBufferMisc(t *testing.T) {
 	_, err = buffer.Read(packet)
 	assert.Equal(io.ErrShortBuffer, err)
 
-	// Try again with the right size
-	packet = make([]byte, 4)
-	n, err = buffer.Read(packet)
-	assert.NoError(err)
-	assert.Equal(4, n)
-
 	// Close
 	err = buffer.Close()
 	assert.NoError(err)


### PR DESCRIPTION
This more than doubles the performance of the current (highly unrealistic) benchmark, and reduces allocation to virtually nothing.  There are some minor API changes, described in the commit messages.

```
name          old time/op    new time/op    delta
Buffer14-4       552ns ± 8%     176ns ± 2%   -68.10%  (p=0.000 n=8+8)
Buffer140-4      435ns ± 5%     227ns ± 2%   -47.81%  (p=0.000 n=8+8)
Buffer1400-4     929ns ± 3%     385ns ± 2%   -58.55%  (p=0.000 n=8+8)

name          old speed      new speed      delta
Buffer14-4    25.4MB/s ± 8%  79.5MB/s ± 2%  +212.67%  (p=0.000 n=8+8)
Buffer140-4    322MB/s ± 5%   617MB/s ± 2%   +91.49%  (p=0.000 n=8+8)
Buffer1400-4  1.51GB/s ± 3%  3.64GB/s ± 2%  +141.27%  (p=0.000 n=8+8)

name          old alloc/op   new alloc/op   delta
Buffer14-4        138B ± 2%        3B ± 0%   -97.83%  (p=0.000 n=6+8)
Buffer140-4       264B ± 1%        4B ± 0%   -98.48%  (p=0.000 n=7+8)
Buffer1400-4    1.45kB ± 0%    0.01kB ± 0%   -99.52%  (p=0.000 n=8+8)

name          old allocs/op  new allocs/op  delta
Buffer14-4        1.00 ± 0%      0.00       -100.00%  (p=0.000 n=8+8)
Buffer140-4       1.00 ± 0%      0.00       -100.00%  (p=0.000 n=8+8)
Buffer1400-4      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=8+8)
```