### PR TITLE
Add ReadContext/WriteContext

### DIFF
--- a/packetio/buffer.go
+++ b/packetio/buffer.go
@@ -2,6 +2,7 @@
 package packetio
 
 import (
+	"context"
 	"errors"
 	"io"
 	"sync"
@@ -178,6 +179,11 @@ func (b *Buffer) Write(packet []byte) (int, error) {
 	return len(packet), nil
 }
 
+// WriteContext writes from the buffer with context.
+func (b *Buffer) WriteContext(ctx context.Context, packet []byte) (int, error) {
+	return b.Write(packet)
+}
+
 // Read populates the given byte slice, returning the number of bytes read.
 // Blocks until data is available or the buffer is closed.
 // Returns io.ErrShortBuffer is the packet is too small to copy the Write.
@@ -190,75 +196,98 @@ func (b *Buffer) Read(packet []byte) (n int, err error) {
 	default:
 	}
 
+	return b.ReadContext(context.Background(), packet)
+}
+
+// ReadContext reads from the buffer with context.
+// Deadline timer is ignored in this function.
+func (b *Buffer) ReadContext(ctx context.Context, packet []byte) (n int, err error) {
+	// Return immediately if the deadline is already exceeded.
+	select {
+	case <-ctx.Done():
+		return 0, &netError{ctx.Err(), true, true}
+	default:
+	}
+
 	for {
-		b.mutex.Lock()
-
-		if b.head != b.tail {
-			// decode the packet size
-			n1 := b.data[b.head]
-			b.head++
-			if b.head >= len(b.data) {
-				b.head = 0
-			}
-			n2 := b.data[b.head]
-			b.head++
-			if b.head >= len(b.data) {
-				b.head = 0
-			}
-			count := int((uint16(n1) << 8) | uint16(n2))
-
-			// determine the number of bytes we'll actually copy
-			copied := count
-			if copied > len(packet) {
-				copied = len(packet)
-			}
-
-			// copy the data
-			if b.head+copied < len(b.data) {
-				copy(packet, b.data[b.head:b.head+copied])
-			} else {
-				k := copy(packet, b.data[b.head:])
-				copy(packet[k:], b.data[:copied-k])
-			}
-
-			// advance head, discarding any data that wasn't copied
-			b.head += count
-			if b.head >= len(b.data) {
-				b.head -= len(b.data)
-			}
-
-			if b.head == b.tail {
-				// the buffer is empty, reset to beginning
-				// in order to improve cache locality.
-				b.head = 0
-				b.tail = 0
-			}
-
-			b.count--
-
-			b.mutex.Unlock()
-
-			if copied < count {
-				return copied, io.ErrShortBuffer
-			}
-			return copied, nil
+		ok, notify, n, err := b.tryRead(packet)
+		if ok {
+			return n, err
 		}
-
-		if b.closed {
-			b.mutex.Unlock()
-			return 0, io.EOF
-		}
-
-		notify := b.notify
-		b.subs = true
-		b.mutex.Unlock()
 
 		select {
 		case <-b.readDeadline.Done():
 			return 0, &netError{errTimeout, true, true}
+		case <-ctx.Done():
+			return 0, &netError{ctx.Err(), true, true}
 		case <-notify:
 		}
 	}
+}
+
+func (b *Buffer) tryRead(packet []byte) (ok bool, notify <-chan struct{}, n int, err error) {
+	b.mutex.Lock()
+
+	if b.head != b.tail {
+		// decode the packet size
+		n1 := b.data[b.head]
+		b.head++
+		if b.head >= len(b.data) {
+			b.head = 0
+		}
+		n2 := b.data[b.head]
+		b.head++
+		if b.head >= len(b.data) {
+			b.head = 0
+		}
+		count := int((uint16(n1) << 8) | uint16(n2))
+
+		// determine the number of bytes we'll actually copy
+		copied := count
+		if copied > len(packet) {
+			copied = len(packet)
+		}
+
+		// copy the data
+		if b.head+copied < len(b.data) {
+			copy(packet, b.data[b.head:b.head+copied])
+		} else {
+			k := copy(packet, b.data[b.head:])
+			copy(packet[k:], b.data[:copied-k])
+		}
+
+		// advance head, discarding any data that wasn't copied
+		b.head += count
+		if b.head >= len(b.data) {
+			b.head -= len(b.data)
+		}
+
+		if b.head == b.tail {
+			// the buffer is empty, reset to beginning
+			// in order to improve cache locality.
+			b.head = 0
+			b.tail = 0
+		}
+
+		b.count--
+
+		b.mutex.Unlock()
+
+		if copied < count {
+			return true, nil, copied, io.ErrShortBuffer
+		}
+		return true, nil, copied, nil
+	}
+
+	if b.closed {
+		b.mutex.Unlock()
+		return true, nil, 0, io.EOF
+	}
+
+	notifyCh := b.notify
+	b.subs = true
+	b.mutex.Unlock()
+	return false, notifyCh, 0, nil
 }
 
 // Close the buffer, unblocking any pending reads.


### PR DESCRIPTION
Read/Write overhead is increased a little bit,
but Read/WriteContext is faster than Read/Write.

### BenchmarkBufferWR14
version        | iter     | op         | bw
-------------- | -------- | ---------- | ---
Old            | 19459795 | 61.1 ns/op | 229.30 MB/s
New NoContext  | 17973650 | 67.2 ns/op | 208.40 MB/s
New Context    | 30738019 | 39.1 ns/op | 358.17 MB/s

### BenchmarkBufferWR140
version        | iter     | op         | bw
-------------- | -------- | ---------- | ---
Old            | 17757152 | 68.1 ns/op | 2056.79 MB/s
New NoContext  | 16810936 | 71.5 ns/op | 1957.94 MB/s
New Context    | 24479403 | 48.6 ns/op | 2883.21 MB/s

### BenchmarkBufferWR1400
version        | iter     | op         | bw
-------------- | -------- | ---------- | ---
Old            | 13673950 | 86.7 ns/op | 16147.15 MB/s
New NoContext  | 13727745 | 86.8 ns/op | 16133.11 MB/s
New Context    | 18450013 | 64.8 ns/op | 21615.95 MB/s

### BenchmarkBufferWWR14
version        | iter     | op         | bw
-------------- | -------- | ---------- | ---
Old            | 18965374 | 63.1 ns/op | 221.96 MB/s
New NoContext  | 18021373 | 66.3 ns/op | 211.27 MB/s
New Context    | 30697444 | 38.5 ns/op | 363.67 MB/s

### BenchmarkBufferWWR140
version        | iter     | op         | bw
-------------- | -------- | ---------- | ---
Old            | 17718662 | 67.6 ns/op | 2069.95 MB/s
New NoContext  | 16284301 | 73.5 ns/op | 1904.41 MB/s
New Context    | 23965249 | 49.5 ns/op | 2825.72 MB/s

### BenchmarkBufferWWR1400
version        | iter     | op         | bw
-------------- | -------- | ---------- | ---
Old            | 12484290 | 96.5 ns/op | 14509.35 MB/s
New NoContext  | 12258870 | 96.9 ns/op | 14445.11 MB/s
New Context    | 16885568 | 70.7 ns/op | 19803.04 MB/s




## Reference issue
https://github.com/pion/transport/pull/74