### PR TITLE
Fix test/BenchmarkUDP

### DIFF
--- a/test/test_test.go
+++ b/test/test_test.go
@@ -47,32 +47,6 @@ func BenchmarkPipe(b *testing.B) {
 	check(Stress(ca, cb, opt))
 }
 
-func BenchmarkUDP(b *testing.B) {
-	var ca net.Conn
-	var cb net.Conn
-
-	ca, err := net.ListenUDP(udpString, nil)
-	check(err)
-	defer func() {
-		check(ca.Close())
-	}()
-
-	cb, err = net.Dial(udpString, ca.LocalAddr().String())
-	check(err)
-	defer func() {
-		check(cb.Close())
-	}()
-
-	b.ResetTimer()
-
-	opt := Options{
-		MsgSize:  2048,
-		MsgCount: b.N,
-	}
-
-	check(Stress(cb, ca, opt))
-}
-
 func check(err error) {
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Stress test requires that the connection never drops a packet.
UDP stream is not suitable to be tested by this.

### Reference issue
Fixes #105
