### PR TITLE
(Discussion) Context changes

### DIFF
--- a/packetio/buffer_test.go
+++ b/packetio/buffer_test.go
@@ -511,22 +511,6 @@ func benchmarkBufferWR(b *testing.B, size int64, write bool, grow int) { // noli
 		}
 	}
 
-	b.Run("NoContext", func(b *testing.B) {
-		b.ResetTimer()
-		b.SetBytes(size)
-
-		for i := 0; i < b.N; i++ {
-			_, err := buffer.Write(packet)
-			if err != nil {
-				b.Fatalf("Write: %v", err)
-			}
-			_, err = buffer.Read(packet)
-			if err != nil {
-				b.Fatalf("Read: %v", err)
-			}
-		}
-		b.StopTimer()
-	})
 	b.Run("Context", func(b *testing.B) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -540,6 +524,22 @@ func benchmarkBufferWR(b *testing.B, size int64, write bool, grow int) { // noli
 				b.Fatalf("Write: %v", err)
 			}
 			_, err = buffer.ReadContext(ctx, packet)
+			if err != nil {
+				b.Fatalf("Read: %v", err)
+			}
+		}
+		b.StopTimer()
+	})
+	b.Run("NoContext", func(b *testing.B) {
+		b.ResetTimer()
+		b.SetBytes(size)
+
+		for i := 0; i < b.N; i++ {
+			_, err := buffer.Write(packet)
+			if err != nil {
+				b.Fatalf("Write: %v", err)
+			}
+			_, err = buffer.Read(packet)
 			if err != nil {
 				b.Fatalf("Read: %v", err)
 			}


### PR DESCRIPTION
Context discussion

#### Description

Previos changes has implemented context in read and write methods on Pion, context internally use two methods to check if it's closed `Done` and `Err` these methods internally use a channel and mutex, this imply more contention on hot paths. 

Currently (and maybe Im not fully understanding) there is no need to make the read/write methods cancellable, the read method can be cancelled by `net.Conn` timeout, and write timeouts can be implemented out of Pion internals if required.

The point is by adding more contention on hot paths, the performance degrades a lot, this PR fixed the `Read` method to omit the creation of the noop `context.Background` so we can see the real perfomance:

```
BenchmarkBufferWR14
BenchmarkBufferWR14/Context
BenchmarkBufferWR14/Context-6         	21068410	        55.8 ns/op	 250.84 MB/s
BenchmarkBufferWR14/NoContext
BenchmarkBufferWR14/NoContext-6       	31273467	        39.2 ns/op	 357.45 MB/s
BenchmarkBufferWR140
BenchmarkBufferWR140/Context
BenchmarkBufferWR140/Context-6        	18236595	        65.5 ns/op	2137.44 MB/s
BenchmarkBufferWR140/NoContext
BenchmarkBufferWR140/NoContext-6      	24440551	        48.9 ns/op	2865.81 MB/s
BenchmarkBufferWR1400
BenchmarkBufferWR1400/Context
BenchmarkBufferWR1400/Context-6       	14133746	        84.1 ns/op	16653.53 MB/s
BenchmarkBufferWR1400/NoContext
BenchmarkBufferWR1400/NoContext-6     	17763186	        67.5 ns/op	20729.45 MB/s
BenchmarkBufferWWR14
BenchmarkBufferWWR14/Context
BenchmarkBufferWWR14/Context-6        	20843000	        57.1 ns/op	 245.37 MB/s
BenchmarkBufferWWR14/NoContext
BenchmarkBufferWWR14/NoContext-6      	30034364	        39.8 ns/op	 351.86 MB/s
BenchmarkBufferWWR140
BenchmarkBufferWWR140/Context
BenchmarkBufferWWR140/Context-6       	17966767	        66.3 ns/op	2112.52 MB/s
BenchmarkBufferWWR140/NoContext
BenchmarkBufferWWR140/NoContext-6     	24303013	        49.4 ns/op	2834.95 MB/s
BenchmarkBufferWWR1400
BenchmarkBufferWWR1400/Context
BenchmarkBufferWWR1400/Context-6      	11622256	       101 ns/op	13831.90 MB/s
BenchmarkBufferWWR1400/NoContext
BenchmarkBufferWWR1400/NoContext-6    	14108354	        85.5 ns/op	16366.36 MB/s
```

These can be magnified by all the methods that checks context upstream.

cc: @Sean-Der @tarrencev @at-wat 



