### PR TITLE
Implemented NetworkConditioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [OrlandoCo](https://github.com/OrlandoCo)
 * [Tarrence van As](https://github.com/tarrencev)
 * [Winlin](https://github.com/ossrs/srs) - *UDP proxy to communicate with real servers*
+* [Antoine Baché](https://github.com/Antonito) *Network Conditioner*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/vnet/network_conditioner.go
+++ b/vnet/network_conditioner.go
@@ -1,0 +1,132 @@
+package vnet
+
+import (
+	"math/rand"
+	"sync/atomic"
+	"time"
+	"unsafe"
+)
+
+const (
+	// NetworkConditionPacketLossDenominator is the denominator by which the `NetworkCondition.PacketLoss` value
+	// will be divided.
+	NetworkConditionPacketLossDenominator uint32 = 1000
+
+	kiloBytesInBytes = 1000
+	// Value chosen arbitrarily, there may be a better one.
+	bandwidthComputeThreshold = 2 * time.Second
+)
+
+// NetworkConditioner hold the NetworkCondition of DownLink and UpLink channels.
+type NetworkConditioner struct {
+	// Internals stats
+
+	// Total of downLink bytes
+	// Must be accessed atomically.
+	inBytes                  uint64
+	pendingInBytes           uint64
+	lastInByteChunkTimestamp int64
+
+	// Total of upLink bytes
+	// Must be accessed atomically.
+	outBytes                  uint64
+	pendingOutBytes           uint64
+	lastOutByteChunkTimestamp int64
+
+	// DownLink represents the DownLink condition.
+	DownLink NetworkCondition
+	// UpLink represents the UpLink condition.
+	UpLink NetworkCondition
+}
+
+func (n *NetworkConditioner) handleDownLink(c Chunk) bool {
+	atomic.AddUint64(&n.pendingInBytes, uint64(len(c.UserData())))
+
+	bandwidthLimiterSleep := n.bandwidthLimiter(&n.DownLink.MaxBandwidth, &n.lastInByteChunkTimestamp, &n.inBytes, &n.pendingInBytes)
+
+	// Apply constant latency if required
+	if sleepNeeded := time.Duration(atomic.LoadInt64((*int64)(&n.DownLink.Latency))) - bandwidthLimiterSleep; sleepNeeded > 0 {
+		time.Sleep(sleepNeeded)
+	}
+
+	return n.DownLink.shouldDropPacket()
+}
+
+func (n *NetworkConditioner) handleUpLink(c Chunk) bool {
+	atomic.AddUint64(&n.pendingOutBytes, uint64(len(c.UserData())))
+
+	bandwidthLimiterSleep := n.bandwidthLimiter(&n.UpLink.MaxBandwidth, &n.lastOutByteChunkTimestamp, &n.outBytes, &n.pendingOutBytes)
+
+	// Apply constant latency if required
+	if sleepNeeded := time.Duration(atomic.LoadInt64((*int64)(&n.UpLink.Latency))) - bandwidthLimiterSleep; sleepNeeded > 0 {
+		time.Sleep(sleepNeeded)
+	}
+
+	return n.UpLink.shouldDropPacket()
+}
+
+func (n *NetworkConditioner) bandwidthLimiter(maxBandwidth **uint32, lastTimestamp *int64, totalBytes *uint64, pendingBytes *uint64) time.Duration {
+	// Is safe because refers to a `MaxBandwidth` field in an initialized NetworkCondition struct.
+	// nolint:gosec
+	bandwidthLimit := (*uint32)(atomic.LoadPointer((*unsafe.Pointer)(unsafe.Pointer(maxBandwidth))))
+	bandwidthLimiterSleep := 0 * time.Millisecond
+
+	if bandwidthLimit != nil {
+		now := time.Now().UnixNano()
+		isFirstLoop := atomic.CompareAndSwapInt64(lastTimestamp, 0, now)
+
+		if !isFirstLoop {
+			duration := now - atomic.LoadInt64(lastTimestamp)
+			if time.Duration(duration) > bandwidthComputeThreshold {
+				previouslyPending := atomic.SwapUint64(pendingBytes, 0)
+
+				bandwidthKbps := (float64(previouslyPending) / float64(duration) * float64(time.Second)) / kiloBytesInBytes
+
+				atomic.AddUint64(totalBytes, previouslyPending)
+				atomic.StoreInt64(lastTimestamp, now)
+
+				if bandwidthKbps > float64(*bandwidthLimit) {
+					exceeding := bandwidthKbps - float64(*bandwidthLimit)
+					bandwidthLimiterSleep = time.Duration(exceeding * float64(time.Second))
+
+					time.Sleep(bandwidthLimiterSleep)
+				}
+			}
+		}
+	}
+
+	return bandwidthLimiterSleep
+}
+
+// NetworkCondition represents the network condition parameter of a data transmission channel direction.
+type NetworkCondition struct {
+	// Latency represents the network delay.
+	Latency time.Duration
+	// MaxBandwidth is the maximum bandwidth, in Kbps.
+	MaxBandwidth *uint32
+	// PacketLoss in percentage.
+	// This value will be divided by NetworkConditionPacketLossDenominator.
+	// Any quotient > 1.00 is meaningless.
+	PacketLoss uint32
+}
+
+// Updates atomically each member of the current NetworkCondition with the new one.
+func (c *NetworkCondition) update(newCondition NetworkCondition) {
+	// Each member is atomically updated, but not the whole struct.
+	// This isn't a problem, as it may only affect a few packets – and removes the need for locks.
+	// nolint:gosec
+	atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&c.MaxBandwidth)), unsafe.Pointer(newCondition.MaxBandwidth))
+	atomic.StoreInt64((*int64)(&c.Latency), int64(newCondition.Latency))
+	atomic.StoreUint32(&c.PacketLoss, newCondition.PacketLoss)
+}
+
+func (c *NetworkCondition) shouldDropPacket() bool {
+	packetLoss := atomic.LoadUint32(&c.PacketLoss)
+
+	// nolint:gosec
+	if packetLoss > 0 && uint32(rand.Int31n(int32(NetworkConditionPacketLossDenominator))) < packetLoss {
+		return true
+	}
+
+	return false
+}

--- a/vnet/network_conditioner_preset_test.go
+++ b/vnet/network_conditioner_preset_test.go
@@ -1,0 +1,26 @@
+package vnet
+
+import (
+	"testing"
+)
+
+func TestNetworkConditionerPresets(t *testing.T) {
+	presets := [...]NetworkConditionerPreset{
+		NetworkConditionerPresetNone,
+		NetworkConditionerPresetFullLoss,
+		NetworkConditionerPreset3G,
+		NetworkConditionerPresetDSL,
+		NetworkConditionerPresetEdge,
+		NetworkConditionerPresetLTE,
+		NetworkConditionerPresetVeryBadNetwork,
+		NetworkConditionerPresetWiFi,
+	}
+
+	for _, preset := range presets {
+		conditioner := NewNetworkConditioner(preset)
+
+		if conditioner == nil {
+			t.Fail()
+		}
+	}
+}

--- a/vnet/network_conditioner_presets.go
+++ b/vnet/network_conditioner_presets.go
@@ -1,0 +1,159 @@
+package vnet
+
+import "time"
+
+// NetworkConditionerPreset represents a kind of NetworkConditioner with pre-defined values.
+type NetworkConditionerPreset int
+
+const (
+	// NetworkConditionerPresetNone represents a NetworkConditioner with no effect.
+	NetworkConditionerPresetNone NetworkConditionerPreset = iota + 1
+
+	// NetworkConditionerPresetFullLoss represents a NetworkConditioner with 100% packet loss.
+	NetworkConditionerPresetFullLoss
+
+	// NetworkConditionerPreset3G represents a NetworkConditioner which replicates typical 3G network condition.
+	NetworkConditionerPreset3G
+
+	// NetworkConditionerPresetDSL represents a NetworkConditioner which replicates typical DSL network condition.
+	NetworkConditionerPresetDSL
+
+	// NetworkConditionerPresetEdge represents a NetworkConditioner which replicates typical EDGE network condition.
+	NetworkConditionerPresetEdge
+
+	// NetworkConditionerPresetLTE represents a NetworkConditioner which replicates typical LTE network condition.
+	NetworkConditionerPresetLTE
+
+	// NetworkConditionerPresetVeryBadNetwork represents a NetworkConditioner which replicates a very bad network condition.
+	NetworkConditionerPresetVeryBadNetwork
+
+	// NetworkConditionerPresetWiFi represents a NetworkConditioner which replicates typical WiFi network condition.
+	NetworkConditionerPresetWiFi
+)
+
+// NewNetworkConditioner creates a new NetworkConditioner from the provided preset.
+// If invalid preset, returns a NetworkConditioner with no effect (same as NetworkConditionerPresetNone).
+func NewNetworkConditioner(preset NetworkConditionerPreset) *NetworkConditioner {
+	switch preset {
+	case NetworkConditionerPresetFullLoss:
+		bandwidth := uint32(0)
+
+		return &NetworkConditioner{
+			DownLink: NetworkCondition{
+				MaxBandwidth: &bandwidth,
+				PacketLoss:   NetworkConditionPacketLossDenominator,
+			},
+			UpLink: NetworkCondition{
+				MaxBandwidth: &bandwidth,
+				PacketLoss:   NetworkConditionPacketLossDenominator,
+			},
+		}
+
+	case NetworkConditionerPreset3G:
+		inBandwidth := uint32(780)
+		outBandwidth := uint32(330)
+		delay := 100 * time.Millisecond
+
+		return &NetworkConditioner{
+			DownLink: NetworkCondition{
+				MaxBandwidth: &inBandwidth,
+				Latency:      delay,
+			},
+			UpLink: NetworkCondition{
+				MaxBandwidth: &outBandwidth,
+				Latency:      delay,
+			},
+		}
+
+	case NetworkConditionerPresetDSL:
+		inBandwidth := uint32(2000)
+		outBandwidth := uint32(256)
+		delay := 5 * time.Millisecond
+
+		return &NetworkConditioner{
+			DownLink: NetworkCondition{
+				MaxBandwidth: &inBandwidth,
+				Latency:      delay,
+			},
+			UpLink: NetworkCondition{
+				MaxBandwidth: &outBandwidth,
+				Latency:      delay,
+			},
+		}
+
+	case NetworkConditionerPresetEdge:
+		inBandwidth := uint32(240)
+		outBandwidth := uint32(200)
+		inDelay := 400 * time.Millisecond
+		outDelay := 440 * time.Millisecond
+
+		return &NetworkConditioner{
+			DownLink: NetworkCondition{
+				MaxBandwidth: &inBandwidth,
+				Latency:      inDelay,
+			},
+			UpLink: NetworkCondition{
+				MaxBandwidth: &outBandwidth,
+				Latency:      outDelay,
+			},
+		}
+
+	case NetworkConditionerPresetLTE:
+		inBandwidth := uint32(50000)
+		outBandwidth := uint32(10000)
+		inDelay := 50 * time.Millisecond
+		outDelay := 65 * time.Millisecond
+
+		return &NetworkConditioner{
+			DownLink: NetworkCondition{
+				MaxBandwidth: &inBandwidth,
+				Latency:      inDelay,
+			},
+			UpLink: NetworkCondition{
+				MaxBandwidth: &outBandwidth,
+				Latency:      outDelay,
+			},
+		}
+
+	case NetworkConditionerPresetVeryBadNetwork:
+		bandwidth := uint32(1000)
+		delay := 500 * time.Millisecond
+		// 10% packet loss
+		packetLoss := uint32(0.1 * float64(NetworkConditionPacketLossDenominator))
+
+		settings := NetworkCondition{
+			MaxBandwidth: &bandwidth,
+			Latency:      delay,
+			PacketLoss:   packetLoss,
+		}
+
+		return &NetworkConditioner{
+			DownLink: settings,
+			UpLink:   settings,
+		}
+
+	case NetworkConditionerPresetWiFi:
+		inBandwidth := uint32(40000)
+		outBandwidth := uint32(33000)
+		delay := 1 * time.Millisecond
+
+		return &NetworkConditioner{
+			DownLink: NetworkCondition{
+				MaxBandwidth: &inBandwidth,
+				Latency:      delay,
+			},
+			UpLink: NetworkCondition{
+				MaxBandwidth: &outBandwidth,
+				Latency:      delay,
+			},
+		}
+
+	case NetworkConditionerPresetNone:
+		fallthrough
+	default:
+		return &NetworkConditioner{
+			DownLink: NetworkCondition{},
+			UpLink:   NetworkCondition{},
+		}
+	}
+}

--- a/vnet/network_conditioner_test.go
+++ b/vnet/network_conditioner_test.go
@@ -1,0 +1,180 @@
+// +build !js
+
+package vnet
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func TestNetworkConditionPacketLoss(t *testing.T) {
+	src := &net.UDPAddr{
+		IP:   net.ParseIP("192.168.0.2"),
+		Port: 1234,
+	}
+	dst := &net.UDPAddr{
+		IP:   net.ParseIP("192.168.0.3"),
+		Port: 5678,
+	}
+
+	t.Run("FullLoss", func(t *testing.T) {
+		conditioner := NewNetworkConditioner(NetworkConditionerPresetFullLoss)
+
+		// Every packet should be dismissed
+		for ndx := 0; ndx < 20; ndx++ {
+			if !conditioner.handleDownLink(newChunkUDP(src, dst)) {
+				t.FailNow()
+			}
+
+			if !conditioner.handleUpLink(newChunkUDP(src, dst)) {
+				t.FailNow()
+			}
+		}
+	})
+
+	t.Run("HeavyLoss", func(t *testing.T) {
+		// 80% packet loss
+		packetLoss := uint32(0.8 * float64(NetworkConditionPacketLossDenominator))
+
+		conditioner := &NetworkConditioner{
+			DownLink: NetworkCondition{
+				PacketLoss: packetLoss,
+			},
+			UpLink: NetworkCondition{
+				PacketLoss: packetLoss,
+			},
+		}
+
+		const totalPackets = 100
+
+		downPackets := 0
+		upPackets := 0
+
+		for ndx := 0; ndx < totalPackets; ndx++ {
+			if !conditioner.handleDownLink(newChunkUDP(src, dst)) {
+				downPackets++
+			}
+
+			if !conditioner.handleUpLink(newChunkUDP(src, dst)) {
+				upPackets++
+			}
+		}
+
+		// Don't assert for specific values, just make sure there is loss.
+		if upPackets == 0 || downPackets == 0 || upPackets == totalPackets || downPackets == totalPackets {
+			t.FailNow()
+		}
+	})
+
+	t.Run("NoLoss", func(t *testing.T) {
+		conditioner := NewNetworkConditioner(NetworkConditionerPresetNone)
+
+		const totalPackets = 100
+
+		downPackets := 0
+		upPackets := 0
+
+		for ndx := 0; ndx < totalPackets; ndx++ {
+			if !conditioner.handleDownLink(newChunkUDP(src, dst)) {
+				downPackets++
+			}
+
+			if !conditioner.handleUpLink(newChunkUDP(src, dst)) {
+				upPackets++
+			}
+		}
+
+		// Don't assert for specific values, just make sure there is loss.
+		if upPackets != totalPackets || downPackets != totalPackets {
+			t.FailNow()
+		}
+	})
+}
+
+func TestNetworkConditionBandwidth(t *testing.T) {
+	src := &net.UDPAddr{
+		IP:   net.ParseIP("192.168.0.2"),
+		Port: 1234,
+	}
+	dst := &net.UDPAddr{
+		IP:   net.ParseIP("192.168.0.3"),
+		Port: 5678,
+	}
+
+	downBandwidthCap := uint32(10)
+	upBandwidthCap := uint32(20)
+
+	conditioner := &NetworkConditioner{
+		DownLink: NetworkCondition{
+			MaxBandwidth: &downBandwidthCap,
+		},
+		UpLink: NetworkCondition{
+			MaxBandwidth: &upBandwidthCap,
+		},
+	}
+
+	testDuration := 10 * time.Second
+
+	pck := newChunkUDP(src, dst)
+
+	downKilobytes := make(chan int, 1)
+	upKilobytes := make(chan int, 1)
+
+	// DownLink loop
+	go func() {
+		timeout := time.NewTimer(testDuration)
+
+		emittedPackets := 0
+
+	loop:
+		for {
+			select {
+			case <-timeout.C:
+				break loop
+			default:
+				if !conditioner.handleDownLink(pck) {
+					emittedPackets++
+				}
+			}
+		}
+
+		downKilobytes <- emittedPackets * len(pck.UserData()) / kiloBytesInBytes
+	}()
+
+	// UpLink loop
+	go func() {
+		timeout := time.NewTimer(testDuration)
+
+		emittedPackets := 0
+
+	loop:
+		for {
+			select {
+			case <-timeout.C:
+				break loop
+			default:
+				if !conditioner.handleUpLink(pck) {
+					emittedPackets++
+				}
+			}
+		}
+
+		upKilobytes <- emittedPackets * len(pck.UserData()) / kiloBytesInBytes
+	}()
+
+	downBandwidth := float64(<-downKilobytes) / testDuration.Seconds()
+	upBandwidth := float64(<-upKilobytes) / testDuration.Seconds()
+
+	if downBandwidth > float64(downBandwidthCap) {
+		t.FailNow()
+	}
+
+	if upBandwidth > float64(upBandwidthCap) {
+		t.FailNow()
+	}
+
+	if upBandwidth < downBandwidth {
+		t.FailNow()
+	}
+}


### PR DESCRIPTION
This PR adds a `NetworkConditioner` on `vnet.Net` – which behaves in addition to the Router's settings.

A `NetworkConditioner` can be provided at `vnet.Net` creation time, or later. 
The change in itself is **not** atomic, rather each value of the  struct is updated atomically. It shouldn't cause any issue though (maybe invalid behavior on 1 or 2 packets at most) and permits to avoid any per-packet locking mechanism – which would hurt performances.

A user can use one of the preset (the values are taken from Apple's NetworkLinkConditioner), or provide their own custom one.

This is useful in situation such as when you need to unit test behavior when a specific user drops their connection.

I'm not 100% sure the `handleDownLink` and `handleUpLink` calls are at the best place nor return the correct values?