### PR TITLE
Make TBF refill only when new chunks arrive

### DIFF
--- a/vnet/tbf_test.go
+++ b/vnet/tbf_test.go
@@ -1,3 +1,6 @@
+//go:build !wasm
+// +build !wasm
+
 package vnet
 
 import (

--- a/vnet/tbf_test.go
+++ b/vnet/tbf_test.go
@@ -36,12 +36,12 @@ func TestTokenBucketFilter(t *testing.T) {
 		assert.Equal(t, sent, received)
 	})
 
-	subTest := func(t *testing.T, capacity int, duration time.Duration) {
+	subTest := func(t *testing.T, capacity int, maxBurst int, duration time.Duration) {
 		log := logging.NewDefaultLoggerFactory().NewLogger("test")
 
 		mnic := newMockNIC(t)
 
-		tbf, err := NewTokenBucketFilter(mnic, TBFRate(capacity))
+		tbf, err := NewTokenBucketFilter(mnic, TBFRate(capacity), TBFMaxBurst(maxBurst))
 		assert.NoError(t, err, "should succeed")
 
 		chunkChan := make(chan Chunk)
@@ -57,26 +57,47 @@ func TestTokenBucketFilter(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
+			totalBytesReceived := 0
+			totalPacketsReceived := 0
 			bytesReceived := 0
 			packetsReceived := 0
 			start := time.Now()
+			last := time.Now()
+
+			ticker := time.NewTicker(time.Second)
+			defer ticker.Stop()
+
 			for {
 				select {
 				case <-ctx.Done():
-					bits := float64(bytesReceived) * 8.0
+					bits := float64(totalBytesReceived) * 8.0
 					rate := bits / time.Since(start).Seconds()
 					mBitPerSecond := rate / float64(MBit)
-
 					// Allow 5% more than capacity due to max bursts
 					assert.Less(t, rate, 1.05*float64(capacity))
-					assert.Greater(t, rate, float64(0))
+					assert.Greater(t, rate, 0.9*float64(capacity))
 
 					log.Infof("duration=%v, bytesReceived=%v, packetsReceived=%v throughput=%.2f Mb/s", time.Since(start), bytesReceived, packetsReceived, mBitPerSecond)
 					return
 
+				case now := <-ticker.C:
+					delta := now.Sub(last)
+					last = now
+					bits := float64(bytesReceived) * 8.0
+					rate := bits / delta.Seconds()
+					mBitPerSecond := rate / float64(MBit)
+					log.Infof("duration=%v, bytesReceived=%v, packetsReceived=%v throughput=%.2f Mb/s", delta, bytesReceived, packetsReceived, mBitPerSecond)
+					// Allow 10% more than capacity due to max bursts
+					assert.Less(t, rate, 1.10*float64(capacity))
+					assert.Greater(t, rate, 0.9*float64(capacity))
+					bytesReceived = 0
+					packetsReceived = 0
+
 				case c := <-chunkChan:
 					bytesReceived += len(c.UserData())
 					packetsReceived++
+					totalBytesReceived += len(c.UserData())
+					totalPacketsReceived++
 				}
 			}
 		}()
@@ -107,14 +128,18 @@ func TestTokenBucketFilter(t *testing.T) {
 	}
 
 	t.Run("500Kbit-s", func(t *testing.T) {
-		subTest(t, 500*KBit, 10*time.Second)
+		subTest(t, 500*KBit, 10*KBit, 10*time.Second)
 	})
 
 	t.Run("1Mbit-s", func(t *testing.T) {
-		subTest(t, 1*MBit, 10*time.Second)
+		subTest(t, 1*MBit, 20*KBit, 10*time.Second)
 	})
 
 	t.Run("2Mbit-s", func(t *testing.T) {
-		subTest(t, 2*MBit, 10*time.Second)
+		subTest(t, 2*MBit, 40*KBit, 10*time.Second)
+	})
+
+	t.Run("8Mbit-s", func(t *testing.T) {
+		subTest(t, 8*MBit, 160*KBit, 10*time.Second)
 	})
 }


### PR DESCRIPTION
This avoids continuously updating the token count, even if no new chunks
arrive. It also updates some default values and uses floats to calculate
the tokens, which makes it more accurate.
