### PR TITLE
Rename Interface.Addresses() to Interface.Addrs()

### DIFF
--- a/examples/vnet-udpproxy/README
+++ b/examples/vnet-udpproxy/README
@@ -3,7 +3,7 @@
 This example demonstrates how VNet can be used to communicate with non-VNet addresses using UDPProxy.
 
 In this example we listen map the VNet Address `10.0.0.11` to a real address of our choice. We then
-send to our real address from three different VNet Addresses.
+send to our real address from three different VNet addresses.
 
 If you pass `-address 192.168.1.3:8000` the traffic will be the following
 

--- a/net.go
+++ b/net.go
@@ -406,8 +406,8 @@ func (ifc *Interface) AddAddress(addr net.Addr) {
 	ifc.addrs = append(ifc.addrs, addr)
 }
 
-// Addresses returns a slice of configured addresses on the interface
-func (ifc *Interface) Addresses() ([]net.Addr, error) {
+// Addrs returns a slice of configured addresses on the interface
+func (ifc *Interface) Addrs() ([]net.Addr, error) {
 	if len(ifc.addrs) == 0 {
 		return nil, ErrNoAddressAssigned
 	}

--- a/stdnet/net_test.go
+++ b/stdnet/net_test.go
@@ -28,13 +28,13 @@ func TestStdNet(t *testing.T) {
 		log.Debugf("interfaces: %+v", interfaces)
 		for _, ifc := range interfaces {
 			if ifc.Name == lo0String {
-				_, err := ifc.Addresses()
+				_, err := ifc.Addrs()
 				if !assert.NoError(t, err, "should succeed") {
 					return
 				}
 			}
 
-			if addrs, err := ifc.Addresses(); err == nil {
+			if addrs, err := ifc.Addrs(); err == nil {
 				for _, addr := range addrs {
 					log.Debugf("[%d] %s:%s",
 						ifc.Index,

--- a/vnet/net.go
+++ b/vnet/net.go
@@ -116,7 +116,7 @@ func (v *Net) getAllIPAddrs(ipv6 bool) []net.IP {
 	ips := []net.IP{}
 
 	for _, ifc := range v.interfaces {
-		addrs, err := ifc.Addresses()
+		addrs, err := ifc.Addrs()
 		if err != nil {
 			continue
 		}
@@ -403,7 +403,7 @@ func (v *Net) determineSourceIP(locIP, dstIP net.IP) net.IP {
 			return nil
 		}
 
-		addrs, err2 := ifc.Addresses()
+		addrs, err2 := ifc.Addrs()
 		if err2 != nil {
 			return nil
 		}
@@ -441,7 +441,7 @@ func (v *Net) determineSourceIP(locIP, dstIP net.IP) net.IP {
 // caller must hold the mutex
 func (v *Net) hasIPAddr(ip net.IP) bool { //nolint:gocognit
 	for _, ifc := range v.interfaces {
-		if addrs, err := ifc.Addresses(); err == nil {
+		if addrs, err := ifc.Addrs(); err == nil {
 			for _, addr := range addrs {
 				var locIP net.IP
 				if ipNet, ok := addr.(*net.IPNet); ok {

--- a/vnet/net_test.go
+++ b/vnet/net_test.go
@@ -38,7 +38,7 @@ func TestNetVirtual(t *testing.T) {
 					ifc.Flags,
 					"Flags mismatch")
 
-				addrs, err := ifc.Addresses()
+				addrs, err := ifc.Addrs()
 				assert.NoError(t, err, "should succeed")
 				assert.Equal(t, 1, len(addrs), "should be one address")
 			case "eth0":
@@ -50,13 +50,13 @@ func TestNetVirtual(t *testing.T) {
 					ifc.Flags,
 					"Flags mismatch")
 
-				_, err := ifc.Addresses()
+				_, err := ifc.Addrs()
 				assert.NotNil(t, err, "should fail")
 			default:
 				assert.Fail(t, "unknown tnet.Interface: %v", ifc.Name)
 			}
 
-			if addrs, err := ifc.Addresses(); err == nil {
+			if addrs, err := ifc.Addrs(); err == nil {
 				for _, addr := range addrs {
 					log.Debugf("[%d] %s:%s",
 						ifc.Index,
@@ -93,7 +93,7 @@ func TestNetVirtual(t *testing.T) {
 				ifc.Flags,
 				"Flags mismatch")
 
-			addrs, err2 := ifc.Addresses()
+			addrs, err2 := ifc.Addrs()
 			assert.NoError(t, err2, "should succeed")
 			assert.Equal(t, 1, len(addrs), "should be one address")
 		}
@@ -108,7 +108,7 @@ func TestNetVirtual(t *testing.T) {
 			ifc.Flags,
 			"Flags mismatch")
 
-		_, err = ifc.Addresses()
+		_, err = ifc.Addrs()
 		assert.NotNil(t, err, "should fail")
 
 		_, err = nw.InterfaceByName("foo0")
@@ -134,7 +134,7 @@ func TestNetVirtual(t *testing.T) {
 			Mask: net.CIDRMask(24, 32),
 		})
 
-		_, err = ifc.Addresses()
+		_, err = ifc.Addrs()
 		assert.NoError(t, err, "should succeed")
 
 		assert.True(t, nw.hasIPAddr(net.ParseIP("127.0.0.1")),

--- a/vnet/router.go
+++ b/vnet/router.go
@@ -554,7 +554,7 @@ func (r *Router) setRouter(parent *Router) error {
 		return err
 	}
 
-	addrs, _ := ifc.Addresses()
+	addrs, _ := ifc.Addrs()
 	if len(addrs) == 0 {
 		return errNoIPAddrEth0
 	}

--- a/vnet/router_test.go
+++ b/vnet/router_test.go
@@ -29,7 +29,7 @@ func getIPAddr(n NIC) (string, error) {
 		return "", err
 	}
 
-	addrs, err := eth0.Addresses()
+	addrs, err := eth0.Addrs()
 	if err != nil {
 		return "", err
 	}
@@ -101,7 +101,7 @@ func TestRouterStandalone(t *testing.T) {
 		eth0, err := nic.getInterface("eth0")
 		assert.Nil(t, err, "should succeed")
 
-		addrs, err := eth0.Addresses()
+		addrs, err := eth0.Addrs()
 		assert.Nil(t, err, "should succeed")
 		assert.Equal(t, 1, len(addrs), "should match")
 		assert.Equal(t, "ip+net", addrs[0].Network(), "should match")
@@ -167,7 +167,7 @@ func TestRouterStandalone(t *testing.T) {
 			// Now, eth0 must have one address assigned
 			eth0, err2 := nic[i].getInterface("eth0")
 			assert.Nil(t, err2, "should succeed")
-			addrs, err2 := eth0.Addresses()
+			addrs, err2 := eth0.Addrs()
 			assert.Nil(t, err2, "should succeed")
 			assert.Equal(t, 1, len(addrs), "should match")
 			//nolint:forcetypeassert
@@ -229,7 +229,7 @@ func TestRouterStandalone(t *testing.T) {
 			// Now, eth0 must have one address assigned
 			eth0, err2 := nic[i].getInterface("eth0")
 			assert.Nil(t, err2, "should succeed")
-			addrs, err2 := eth0.Addresses()
+			addrs, err2 := eth0.Addrs()
 			assert.Nil(t, err2, "should succeed")
 			assert.Equal(t, 1, len(addrs), "should match")
 			//nolint:forcetypeassert
@@ -332,7 +332,7 @@ func TestRouterDelay(t *testing.T) {
 				// Now, eth0 must have one address assigned
 				eth0, err2 := nic[i].getInterface("eth0")
 				assert.Nil(t, err2, "should succeed")
-				addrs, err2 := eth0.Addresses()
+				addrs, err2 := eth0.Addrs()
 				assert.Nil(t, err2, "should succeed")
 				assert.Equal(t, 1, len(addrs), "should match")
 				//nolint:forcetypeassert

--- a/vnet/stress_test.go
+++ b/vnet/stress_test.go
@@ -82,7 +82,7 @@ func TestStressTestUDP(t *testing.T) {
 				continue
 			}
 
-			addrs, err2 := ifc.Addresses()
+			addrs, err2 := ifc.Addrs()
 			if !assert.NoError(t, err2, "should succeed") {
 				return
 			}


### PR DESCRIPTION
In order to align our `transport.Interface` wrapper more closely to Go's `net.Interface` type.
