### PR TITLE
connctx benchmarks

### DIFF
--- a/connctx/connctx_test.go
+++ b/connctx/connctx_test.go
@@ -46,7 +46,7 @@ func TestRead(t *testing.T) {
 	}
 }
 
-func TestReadTImeout(t *testing.T) {
+func TestReadTimeout(t *testing.T) {
 	ca, _ := net.Pipe()
 	defer func() {
 		_ = ca.Close()

--- a/connctx/connctx_test.go
+++ b/connctx/connctx_test.go
@@ -259,7 +259,7 @@ func BenchmarkBase(b *testing.B) {
 	for {
 		n, err := ca.Read(buf)
 		if err != nil {
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				b.Fatal(err)
 			}
 			break
@@ -301,7 +301,7 @@ func BenchmarkWrite(b *testing.B) {
 	for {
 		n, err := ca.Read(buf)
 		if err != nil {
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				b.Fatal(err)
 			}
 			break
@@ -343,7 +343,7 @@ func BenchmarkRead(b *testing.B) {
 	for {
 		n, err := c.ReadContext(context.Background(), buf)
 		if err != nil {
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				b.Fatal(err)
 			}
 			break


### PR DESCRIPTION
- Fix typo in TestReadTimeout
- Add benchmarks for connctx

```
goos: linux
goarch: amd64
pkg: github.com/pion/transport/v2/connctx
cpu: Intel(R) Core(TM) i5-8350U CPU @ 1.70GHz
BenchmarkBase-8    	  956014	      1324 ns/op	3094.11 MB/s	       0 B/op	       0 allocs/op
BenchmarkWrite-8   	  399874	      2559 ns/op	1600.41 MB/s	     192 B/op	       4 allocs/op
BenchmarkRead-8    	  520050	      2319 ns/op	1766.26 MB/s	     192 B/op	       4 allocs/op
PASS
ok  	github.com/pion/transport/v2/connctx	4.742s
```
