### PR TITLE
Notify read error if udp.listener.readloop exit

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -6,6 +6,7 @@
 Adrian Cable <adrian.cable@gmail.com>
 Atsushi Watanabe <atsushi.w@ieee.org>
 backkem <mail@backkem.me>
+cnderrauber <zengjie9004@gmail.com>
 Hugo Arregui <hugo.arregui@gmail.com>
 Jeremiah Millay <jmillay@fastly.com>
 Jozef Kralik <jojo.lwin@gmail.com>


### PR DESCRIPTION
Notify read error if udp.listener.readloop exit,
also fix #238 

#### Description
If listener.readloop encounter an error and exit, the accept will never return as no connection is created.

#### Reference issue
Fixes #...
