### PR TITLE
Add support for custom UDP connection identifiers

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -7,6 +7,7 @@ Adrian Cable <adrian.cable@gmail.com>
 Atsushi Watanabe <atsushi.w@ieee.org>
 backkem <mail@backkem.me>
 cnderrauber <zengjie9004@gmail.com>
+Dan Mangum <georgedanielmangum@gmail.com>
 Hugo Arregui <hugo.arregui@gmail.com>
 Jeremiah Millay <jmillay@fastly.com>
 Jozef Kralik <jojo.lwin@gmail.com>


### PR DESCRIPTION
#### Description

Adds support for custom UDP connection identifiers. If a ConnIDFn is
provided, the result will be used as the identifier of a connection
rather then the remote address. If a connection already exists for the
remote address, its identifier will be updated to the connection ID. If
the remote address for packets associated with a connection identifier
changes, the remote address of the connection will also be updated.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>

Adds unit testing to ensure that a custom UDP connection identifier
results in expected behavior. Testing adheres to the following steps:

1. Initiate 5 connections using remote address as identifier.
2. Send message on each connection that results in migration from remote
   address identifier to custom identifier.
3. Spawn 20 clients, each assigned to send one message on one of the
   connections (total of 4 messages on each connection).
4. Spawn 5 servers and ensure that each receives the first initiation
   and set messages, then 4 messages, each originating from a different
   remote address.

Signed-off-by: Daniel Mangum <georgedanielmangum@gmail.com>

#### Reference issue

Part of https://github.com/pion/dtls/issues/256
