### PR TITLE
Broadcast notify on Buffer.Close

### DIFF
--- a/packetio/buffer.go
+++ b/packetio/buffer.go
@@ -287,10 +287,7 @@ func (b *Buffer) Close() (err error) {
 	b.mutex.Unlock()
 
 	if waiting {
-		select {
-		case b.notify <- struct{}{}:
-		default:
-		}
+		close(b.notify)
 	}
 
 	return nil


### PR DESCRIPTION
#### Description
This changes Close from being a "signaler" to a "broadcaster" of the notify condition. There's a small, but possible chance that between `Unlock` and `select` at the bottom of `Read` that we will have concurrent reads in the same position which means only once can receive a notify. If a `Close` happens in between this time, one or more reads will be blocked. One such case where this happen is for an srtp and srtcp reader.

In a simpler case, one read in the same position may miss a notify event during a Close. This affects any basic use of a *packetio.Buffer.

#### Reference issue
Fixes #298 and #299 (maybe)

I reproduced this with synchronization points at the critical point mentioned such that we start 2 reads, close before the select, and then continue the reads, at which point the test will time out. The new test, as such, is non-deterministic without the manual sync points.

