### PR TITLE
Update lint rules, force testify/assert for tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,12 +19,16 @@ linters-settings:
             recommendations:
               - errors
   forbidigo:
+    analyze-types: true
     forbid:
       - ^fmt.Print(f|ln)?$
       - ^log.(Panic|Fatal|Print)(f|ln)?$
       - ^os.Exit$
       - ^panic$
       - ^print(ln)?$
+      - p: ^testing.T.(Error|Errorf|Fatal|Fatalf|Fail|FailNow)$
+        pkg: ^testing$
+        msg: "use testify/assert instead"
   varnamelen:
     max-distance: 12
     min-name-length: 2
@@ -127,9 +131,12 @@ issues:
   exclude-dirs-use-default: false
   exclude-rules:
     # Allow complex tests and examples, better to be self contained
-    - path: (examples|main\.go|_test\.go)
+    - path: (examples|main\.go)
       linters:
+        - gocognit
         - forbidigo
+    - path: _test\.go
+      linters:
         - gocognit
 
     # Allow forbidden identifiers in CLI commands

--- a/netctx/conn_test.go
+++ b/netctx/conn_test.go
@@ -4,13 +4,14 @@
 package netctx
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"io"
 	"net"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRead(t *testing.T) {
@@ -30,20 +31,11 @@ func TestRead(t *testing.T) {
 	c := NewConn(ca)
 	b := make([]byte, 100)
 	n, err := c.ReadContext(context.Background(), b)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != len(data) {
-		t.Errorf("Wrong data length, expected %d, got %d", len(data), n)
-	}
-	if !bytes.Equal(data, b[:n]) {
-		t.Errorf("Wrong data, expected %v, got %v", data, b)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, len(data), n)
+	assert.Equal(t, data, b[:n])
 
-	err = <-chErr
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, <-chErr)
 }
 
 func TestReadTimeout(t *testing.T) {
@@ -58,12 +50,8 @@ func TestReadTimeout(t *testing.T) {
 	c := NewConn(ca)
 	b := make([]byte, 100)
 	n, err := c.ReadContext(ctx, b)
-	if err == nil {
-		t.Error("Read unexpectedly succeeded")
-	}
-	if n != 0 {
-		t.Errorf("Wrong data length, expected %d, got %d", 0, n)
-	}
+	assert.Error(t, err)
+	assert.Empty(t, n)
 }
 
 func TestReadCancel(t *testing.T) {
@@ -81,12 +69,8 @@ func TestReadCancel(t *testing.T) {
 	c := NewConn(ca)
 	b := make([]byte, 100)
 	n, err := c.ReadContext(ctx, b)
-	if err == nil {
-		t.Error("Read unexpectedly succeeded")
-	}
-	if n != 0 {
-		t.Errorf("Wrong data length, expected %d, got %d", 0, n)
-	}
+	assert.Error(t, err)
+	assert.Empty(t, n)
 }
 
 func TestReadClosed(t *testing.T) {
@@ -97,12 +81,8 @@ func TestReadClosed(t *testing.T) {
 
 	b := make([]byte, 100)
 	n, err := c.ReadContext(context.Background(), b)
-	if !errors.Is(err, net.ErrClosed) {
-		t.Errorf("Expected error '%v', got '%v'", net.ErrClosed, err)
-	}
-	if n != 0 {
-		t.Errorf("Wrong data length, expected %d, got %d", 0, n)
-	}
+	assert.ErrorIs(t, err, net.ErrClosed)
+	assert.Empty(t, n)
 }
 
 func TestWrite(t *testing.T) {
@@ -124,21 +104,13 @@ func TestWrite(t *testing.T) {
 	c := NewConn(ca)
 	data := []byte{0x01, 0x02, 0xFF}
 	n, err := c.WriteContext(context.Background(), data)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n != len(data) {
-		t.Errorf("Wrong data length, expected %d, got %d", len(data), n)
-	}
+	assert.NoError(t, err)
+	assert.Len(t, data, n)
 
 	err = <-chErr
 	b := <-chRead
-	if !bytes.Equal(data, b) {
-		t.Errorf("Wrong data, expected %v, got %v", data, b)
-	}
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, data, b)
 }
 
 func TestWriteTimeout(t *testing.T) {
@@ -153,12 +125,8 @@ func TestWriteTimeout(t *testing.T) {
 	c := NewConn(ca)
 	b := make([]byte, 100)
 	n, err := c.WriteContext(ctx, b)
-	if err == nil {
-		t.Error("Write unexpectedly succeeded")
-	}
-	if n != 0 {
-		t.Errorf("Wrong data length, expected %d, got %d", 0, n)
-	}
+	assert.Error(t, err)
+	assert.Empty(t, n)
 }
 
 func TestWriteCancel(t *testing.T) {
@@ -176,12 +144,8 @@ func TestWriteCancel(t *testing.T) {
 	c := NewConn(ca)
 	b := make([]byte, 100)
 	n, err := c.WriteContext(ctx, b)
-	if err == nil {
-		t.Error("Write unexpectedly succeeded")
-	}
-	if n != 0 {
-		t.Errorf("Wrong data length, expected %d, got %d", 0, n)
-	}
+	assert.Error(t, err)
+	assert.Empty(t, n)
 }
 
 func TestWriteClosed(t *testing.T) {
@@ -192,12 +156,8 @@ func TestWriteClosed(t *testing.T) {
 
 	b := make([]byte, 100)
 	n, err := c.WriteContext(context.Background(), b)
-	if !errors.Is(err, ErrClosing) {
-		t.Errorf("Expected error '%v', got '%v'", ErrClosing, err)
-	}
-	if n != 0 {
-		t.Errorf("Wrong data length, expected %d, got %d", 0, n)
-	}
+	assert.ErrorIs(t, err, ErrClosing)
+	assert.Empty(t, n)
 }
 
 // Test for TestLocalAddrAndRemoteAddr.
@@ -211,26 +171,40 @@ func (a stringAddr) String() string  { return a.addr }
 
 type connAddrMock struct{}
 
-func (*connAddrMock) RemoteAddr() net.Addr               { return stringAddr{"remote_net", "remote_addr"} }
-func (*connAddrMock) LocalAddr() net.Addr                { return stringAddr{"local_net", "local_addr"} }
-func (*connAddrMock) Read(_ []byte) (n int, err error)   { panic("unimplemented") }
-func (*connAddrMock) Write(_ []byte) (n int, err error)  { panic("unimplemented") }
-func (*connAddrMock) Close() error                       { panic("unimplemented") }
-func (*connAddrMock) SetDeadline(_ time.Time) error      { panic("unimplemented") }
-func (*connAddrMock) SetReadDeadline(_ time.Time) error  { panic("unimplemented") }
-func (*connAddrMock) SetWriteDeadline(_ time.Time) error { panic("unimplemented") }
+func (*connAddrMock) RemoteAddr() net.Addr { return stringAddr{"remote_net", "remote_addr"} }
+func (*connAddrMock) LocalAddr() net.Addr  { return stringAddr{"local_net", "local_addr"} }
+
+func (*connAddrMock) Read(_ []byte) (n int, err error) {
+	panic("unimplemented") //nolint
+}
+
+func (*connAddrMock) Write(_ []byte) (n int, err error) {
+	panic("unimplemented") //nolint
+}
+
+func (*connAddrMock) Close() error {
+	panic("unimplemented") //nolint
+}
+
+func (*connAddrMock) SetDeadline(_ time.Time) error {
+	panic("unimplemented") //nolint
+}
+
+func (*connAddrMock) SetReadDeadline(_ time.Time) error {
+	panic("unimplemented") //nolint
+}
+
+func (*connAddrMock) SetWriteDeadline(_ time.Time) error {
+	panic("unimplemented") //nolint
+}
 
 func TestLocalAddrAndRemoteAddr(t *testing.T) {
 	c := NewConn(&connAddrMock{})
 	al := c.LocalAddr()
 	ar := c.RemoteAddr()
 
-	if al.String() != "local_addr" {
-		t.Error("Wrong LocalAddr implementation")
-	}
-	if ar.String() != "remote_addr" {
-		t.Error("Wrong RemoteAddr implementation")
-	}
+	assert.Equal(t, "local_addr", al.String())
+	assert.Equal(t, "remote_addr", ar.String())
 }
 
 func BenchmarkBase(b *testing.B) {

--- a/packetio/buffer_test.go
+++ b/packetio/buffer_test.go
@@ -38,9 +38,8 @@ func TestBuffer(t *testing.T) {
 	assert.NoError(err)
 	n, err = buffer.Read(packet)
 	var e net.Error
-	if !errors.As(err, &e) || !e.Timeout() {
-		t.Errorf("Unexpected error: %v", err)
-	}
+	assert.ErrorAs(err, &e)
+	assert.True(e.Timeout())
 	assert.Equal(0, n)
 
 	// Reset deadline
@@ -376,7 +375,7 @@ func TestBufferLimitSizes(t *testing.T) {
 				assert.NoError(err)
 				assert.Equal(packetSize, n)
 				if err != nil {
-					t.FailNow()
+					assert.FailNow("Read failed", err)
 				}
 			}
 		})
@@ -415,11 +414,7 @@ func TestBufferAlloc(t *testing.T) {
 			t.Helper()
 
 			allocs := testing.AllocsPerRun(3, f(count))
-			if allocs > maxVal {
-				t.Errorf("count=%v, max=%v, got %v",
-					count, maxVal, allocs,
-				)
-			}
+			assert.LessOrEqualf(t, allocs, maxVal, "count=%v, max=%v, got %v", count, maxVal, allocs)
 		}
 	}
 
@@ -428,11 +423,7 @@ func TestBufferAlloc(t *testing.T) {
 			buffer := NewBuffer()
 			for i := 0; i < count; i++ {
 				_, err := buffer.Write(packet)
-				if err != nil {
-					t.Errorf("Write: %v", err)
-
-					break
-				}
+				assert.NoError(t, err, "Write")
 			}
 		}
 	}
@@ -447,13 +438,9 @@ func TestBufferAlloc(t *testing.T) {
 			buffer := NewBuffer()
 			for i := 0; i < count; i++ {
 				_, err := buffer.Write(packet)
-				if err != nil {
-					t.Fatalf("Write: %v", err)
-				}
+				assert.NoError(t, err, "Write")
 				_, err = buffer.Read(packet)
-				if err != nil {
-					t.Fatalf("Read: %v", err)
-				}
+				assert.NoError(t, err, "Read")
 			}
 		}
 	}

--- a/replaydetector/replaydetector_test.go
+++ b/replaydetector/replaydetector_test.go
@@ -4,8 +4,9 @@
 package replaydetector
 
 import (
-	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type testCase struct {
@@ -196,21 +197,13 @@ func TestReplayDetector(t *testing.T) {
 			var out []uint64
 			for i, seq := range testCase.input {
 				accept, ok := det.Check(seq)
-				if ok != testCase.valid[i] {
-					t.Errorf("Unexpected validity (%d):\nexpected: %v\ngot: %v", seq, testCase.valid[i], ok)
-				}
+				assert.Equal(t, testCase.valid[i], ok, "Unexpected validity")
 				if ok {
 					out = append(out, seq)
 				}
-				if latest := accept(); latest != testCase.latest[i] {
-					t.Errorf("Unexpected sequence latest status (%d):\nexpected: %v\ngot: %v", seq, testCase.latest[i], latest)
-				}
+				assert.Equal(t, testCase.latest[i], accept(), "Unexpected sequence latest status")
 			}
-			if !reflect.DeepEqual(testCase.expected, out) {
-				t.Errorf("Wrong replay detection result:\nexpected: %v\ngot:      %v",
-					testCase.expected, out,
-				)
-			}
+			assert.Equal(t, testCase.expected, out, "Wrong replay detection result")
 		})
 	}
 }
@@ -252,9 +245,8 @@ func TestReplayDetectorWrapped(t *testing.T) {
 		},
 	}
 	for name, c := range commonCases {
-		if _, ok := cases[name]; ok {
-			t.Fatalf("Duplicate test case name: %q", name)
-		}
+		_, ok := cases[name]
+		assert.False(t, ok, "Duplicate test case name: %q", name)
 		cases[name] = c
 	}
 	for name, c := range cases {
@@ -264,21 +256,13 @@ func TestReplayDetectorWrapped(t *testing.T) {
 			var out []uint64
 			for i, seq := range testCase.input {
 				accept, ok := det.Check(seq)
-				if ok != testCase.valid[i] {
-					t.Errorf("Unexpected validity (%d):\nexpected: %v\ngot: %v", seq, testCase.valid[i], ok)
-				}
+				assert.Equal(t, testCase.valid[i], ok, "Unexpected validity")
 				if ok {
 					out = append(out, seq)
 				}
-				if latest := accept(); latest != testCase.latest[i] {
-					t.Errorf("Unexpected sequence latest status (%d):\nexpected: %v\ngot: %v", seq, testCase.latest[i], latest)
-				}
+				assert.Equal(t, testCase.latest[i], accept(), "Unexpected sequence latest status")
 			}
-			if !reflect.DeepEqual(testCase.expected, out) {
-				t.Errorf("Wrong replay detection result:\nexpected: %v\ngot:      %v",
-					testCase.expected, out,
-				)
-			}
+			assert.Equal(t, testCase.expected, out, "Wrong replay detection result")
 		})
 	}
 }

--- a/test/bridge.go
+++ b/test/bridge.go
@@ -447,6 +447,7 @@ func (br *Bridge) SetLossChance(chance int) error {
 		return errBadLossChanceRange
 	}
 
+	//nolint:staticcheck
 	rand.Seed(time.Now().UTC().UnixNano())
 	br.conn0.lossChance = chance
 	br.conn1.lossChance = chance

--- a/test/bridge_test.go
+++ b/test/bridge_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/nettest"
 )
 
@@ -45,29 +46,14 @@ func TestBridge(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		conn0 := br.GetConn0()
 		conn1 := br.GetConn1()
 
-		if conn0.LocalAddr().String() != "a0" {
-			t.Error("conn0 local addr name should be a0")
-		}
-
-		if conn1.LocalAddr().String() != "a1" {
-			t.Error("conn0 local addr name should be a1")
-		}
-
-		if conn0.LocalAddr().Network() != "udp" {
-			t.Error("conn0 local addr name should be a0")
-		}
-
-		if conn1.LocalAddr().Network() != "udp" {
-			t.Error("conn0 local addr name should be a1")
-		}
+		assert.Equal(t, "a0", conn0.LocalAddr().String())
+		assert.Equal(t, "a1", conn1.LocalAddr().String())
+		assert.Equal(t, "udp", conn0.LocalAddr().Network())
+		assert.Equal(t, "udp", conn1.LocalAddr().Network())
 
 		n, err := conn0.Write([]byte(msg1))
-		if err != nil {
-			t.Error(err.Error())
-		}
-		if n != len(msg1) {
-			t.Error("unexpected length")
-		}
+		assert.NoError(t, err)
+		assert.Len(t, msg1, n, "unexpected length")
 
 		go func() {
 			nInner, errInner := conn1.Read(buf)
@@ -77,15 +63,9 @@ func TestBridge(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		br.Process()
 
 		ar := <-readRes
-		if ar.err != nil {
-			t.Error(err.Error())
-		}
-		if ar.n != len(msg1) {
-			t.Error("unexpected length")
-		}
-		if err = closeBridge(br); err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, ar.err)
+		assert.Len(t, msg1, ar.n, "unexpected length")
+		assert.NoError(t, closeBridge(br))
 	})
 
 	t.Run("drop 1st packet from conn0", func(t *testing.T) { //nolint:dupl
@@ -95,19 +75,11 @@ func TestBridge(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		conn1 := br.GetConn1()
 
 		n, err := conn0.Write([]byte(msg1))
-		if err != nil {
-			t.Error(err.Error())
-		}
-		if n != len(msg1) {
-			t.Error("unexpected length")
-		}
+		assert.NoError(t, err)
+		assert.Len(t, msg1, n, "unexpected length")
 		n, err = conn0.Write([]byte(msg2))
-		if err != nil {
-			t.Error(err.Error())
-		}
-		if n != len(msg2) {
-			t.Error("unexpected length")
-		}
+		assert.NoError(t, err)
+		assert.Len(t, msg2, n, "unexpected length")
 
 		go func() {
 			nInner, errInner := conn1.Read(buf)
@@ -118,15 +90,9 @@ func TestBridge(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		br.Process()
 
 		ar := <-readRes
-		if ar.err != nil {
-			t.Error(err.Error())
-		}
-		if ar.n != len(msg2) {
-			t.Error("unexpected length")
-		}
-		if err = closeBridge(br); err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, ar.err)
+		assert.Len(t, msg2, ar.n, "unexpected length")
+		assert.NoError(t, closeBridge(br))
 	})
 
 	t.Run("drop 2nd packet from conn0", func(t *testing.T) { //nolint:dupl
@@ -136,19 +102,11 @@ func TestBridge(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		conn1 := br.GetConn1()
 
 		n, err := conn0.Write([]byte(msg1))
-		if err != nil {
-			t.Error(err.Error())
-		}
-		if n != len(msg1) {
-			t.Error("unexpected length")
-		}
+		assert.NoError(t, err)
+		assert.Len(t, msg1, n, "unexpected length")
 		n, err = conn0.Write([]byte(msg2))
-		if err != nil {
-			t.Error(err.Error())
-		}
-		if n != len(msg2) {
-			t.Error("unexpected length")
-		}
+		assert.NoError(t, err)
+		assert.Len(t, msg2, n, "unexpected length")
 
 		go func() {
 			nInner, errInner := conn1.Read(buf)
@@ -159,15 +117,9 @@ func TestBridge(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		br.Process()
 
 		ar := <-readRes
-		if ar.err != nil {
-			t.Error(err.Error())
-		}
-		if ar.n != len(msg1) {
-			t.Error("unexpected length")
-		}
-		if err = closeBridge(br); err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, ar.err)
+		assert.Len(t, msg1, ar.n, "unexpected length")
+		assert.NoError(t, closeBridge(br))
 	})
 
 	t.Run("drop 1st packet from conn1", func(t *testing.T) { //nolint:dupl
@@ -177,19 +129,11 @@ func TestBridge(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		conn1 := br.GetConn1()
 
 		n, err := conn1.Write([]byte(msg1))
-		if err != nil {
-			t.Error(err.Error())
-		}
-		if n != len(msg1) {
-			t.Error("unexpected length")
-		}
+		assert.NoError(t, err)
+		assert.Len(t, msg1, n, "unexpected length")
 		n, err = conn1.Write([]byte(msg2))
-		if err != nil {
-			t.Error(err.Error())
-		}
-		if n != len(msg2) {
-			t.Error("unexpected length")
-		}
+		assert.NoError(t, err)
+		assert.Len(t, msg2, n, "unexpected length")
 
 		go func() {
 			nInner, errInner := conn0.Read(buf)
@@ -200,15 +144,9 @@ func TestBridge(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		br.Process()
 
 		ar := <-readRes
-		if ar.err != nil {
-			t.Error(err.Error())
-		}
-		if ar.n != len(msg2) {
-			t.Error("unexpected length")
-		}
-		if err = closeBridge(br); err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, ar.err)
+		assert.Len(t, msg2, ar.n, "unexpected length")
+		assert.NoError(t, closeBridge(br))
 	})
 
 	t.Run("drop 2nd packet from conn1", func(t *testing.T) { //nolint:dupl
@@ -218,19 +156,11 @@ func TestBridge(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		conn1 := br.GetConn1()
 
 		n, err := conn1.Write([]byte(msg1))
-		if err != nil {
-			t.Error(err.Error())
-		}
-		if n != len(msg1) {
-			t.Error("unexpected length")
-		}
+		assert.NoError(t, err)
+		assert.Len(t, msg1, n, "unexpected length")
 		n, err = conn1.Write([]byte(msg2))
-		if err != nil {
-			t.Error(err.Error())
-		}
-		if n != len(msg2) {
-			t.Error("unexpected length")
-		}
+		assert.NoError(t, err)
+		assert.Len(t, msg2, n, "unexpected length")
 
 		go func() {
 			nInner, errInner := conn0.Read(buf)
@@ -241,15 +171,9 @@ func TestBridge(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		br.Process()
 
 		ar := <-readRes
-		if ar.err != nil {
-			t.Error(err.Error())
-		}
-		if ar.n != len(msg1) {
-			t.Error("unexpected length")
-		}
-		if err = closeBridge(br); err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, ar.err)
+		assert.Len(t, msg1, ar.n, "unexpected length")
+		assert.NoError(t, closeBridge(br))
 	})
 
 	t.Run("reorder packets from conn0", func(t *testing.T) { //nolint:dupl
@@ -258,49 +182,29 @@ func TestBridge(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		conn1 := br.GetConn1()
 
 		n, err := conn0.Write([]byte(msg1))
-		if err != nil {
-			t.Error(err.Error())
-		}
-		if n != len(msg1) {
-			t.Error("unexpected length")
-		}
+		assert.NoError(t, err)
+		assert.Len(t, msg1, n, "unexpected length")
 		n, err = conn0.Write([]byte(msg2))
-		if err != nil {
-			t.Error(err.Error())
-		}
-		if n != len(msg2) {
-			t.Error("unexpected length")
-		}
+		assert.NoError(t, err)
+		assert.Len(t, msg2, n, "unexpected length")
 
 		done := make(chan bool)
 
 		go func() {
 			nInner, errInner := conn1.Read(buf)
-			if errInner != nil {
-				t.Error(errInner.Error())
-			}
-			if nInner != len(msg2) {
-				t.Error("unexpected length")
-			}
+			assert.NoError(t, errInner)
+			assert.Len(t, msg2, nInner, "unexpected length")
 			nInner, errInner = conn1.Read(buf)
-			if errInner != nil {
-				t.Error(errInner.Error())
-			}
-			if nInner != len(msg1) {
-				t.Error("unexpected length")
-			}
+			assert.NoError(t, errInner)
+			assert.Len(t, msg1, nInner, "unexpected length")
 			done <- true
 		}()
 
 		err = br.Reorder(0)
-		if err != nil {
-			t.Error(err.Error())
-		}
+		assert.NoError(t, err)
 		br.Process()
 		<-done
-		if err = closeBridge(br); err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, closeBridge(br))
 	})
 
 	t.Run("reorder packets from conn1", func(t *testing.T) { //nolint:dupl
@@ -309,57 +213,35 @@ func TestBridge(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		conn1 := br.GetConn1()
 
 		n, err := conn1.Write([]byte(msg1))
-		if err != nil {
-			t.Error(err.Error())
-		}
-		if n != len(msg1) {
-			t.Error("unexpected length")
-		}
+		assert.NoError(t, err)
+		assert.Len(t, msg1, n, "unexpected length")
 		n, err = conn1.Write([]byte(msg2))
-		if err != nil {
-			t.Error(err.Error())
-		}
-		if n != len(msg2) {
-			t.Error("unexpected length")
-		}
+		assert.NoError(t, err)
+		assert.Len(t, msg2, n, "unexpected length")
 
 		done := make(chan bool)
 
 		go func() {
 			nInner, errInner := conn0.Read(buf)
-			if errInner != nil {
-				t.Error(errInner.Error())
-			}
-			if nInner != len(msg2) {
-				t.Error("unexpected length")
-			}
+			assert.NoError(t, errInner)
+			assert.Len(t, msg2, nInner, "unexpected length")
 			nInner, errInner = conn0.Read(buf)
-			if errInner != nil {
-				t.Error(errInner.Error())
-			}
-			if nInner != len(msg1) {
-				t.Error("unexpected length")
-			}
+			assert.NoError(t, errInner)
+			assert.Len(t, msg1, nInner, "unexpected length")
 			done <- true
 		}()
 
 		err = br.Reorder(1)
-		if err != nil {
-			t.Error(err.Error())
-		}
+		assert.NoError(t, err)
 		br.Process()
 		<-done
-		if err = closeBridge(br); err != nil {
-			t.Error(err)
-		}
+		assert.NoError(t, closeBridge(br))
 	})
 
 	t.Run("inverse error", func(t *testing.T) {
 		q := [][]byte{}
 		q = append(q, []byte("ABC"))
-		if err := inverse(q); err == nil {
-			t.Error("inverse should fail if less than 2 pkts")
-		}
+		assert.Error(t, inverse(q), "inverse should fail if less than 2 pkts")
 	})
 
 	t.Run("drop next N packets", func(t *testing.T) {
@@ -405,35 +287,23 @@ func TestBridge(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 				msg := fmt.Sprintf("msg%d", i)
 				msgs = append(msgs, msg)
 				n, err := srcConn.Write([]byte(msg))
-				if err != nil {
-					t.Errorf("[%d] %s", fromID, err.Error())
-				}
-				if n != len(msg) {
-					t.Errorf("[%d] unexpected length", fromID)
-				}
+				assert.NoErrorf(t, err, "Test: %d", fromID)
+				assert.Len(t, msg, n, "[%d] unexpected length", fromID)
 
 				br.Process()
 			}
 
-			if err := closeBridge(br); err != nil {
-				t.Errorf("[%d] %s", fromID, err.Error())
-			}
+			assert.NoErrorf(t, closeBridge(br), "Test: %d", fromID)
 			br.Process()
 			wg.Wait()
 
-			nResults := len(readRes)
-			if nResults != 2 {
-				t.Errorf("[%d] unexpected number of packets, expected %v, got %v", fromID, 2, nResults)
-			}
+			assert.Lenf(t, readRes, 2, "[%d] unexpected number of packets", fromID)
 
 			for i := 0; i < 2; i++ {
 				ar := <-readRes
-				if ar.err != nil {
-					t.Errorf("[%d] %s", fromID, ar.err.Error())
-				}
-				if ar.n != len(msgs[i+3]) {
-					t.Errorf("[%d] unexpected length", fromID)
-				}
+				assert.NoErrorf(t, ar.err, "Test: %d", fromID)
+
+				assert.Len(t, msgs[i+3], ar.n, "[%d] unexpected length", fromID)
 			}
 		}
 

--- a/test/test_test.go
+++ b/test/test_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStressIOPipe(t *testing.T) {
@@ -17,10 +19,7 @@ func TestStressIOPipe(t *testing.T) {
 		MsgCount: 100,
 	}
 
-	err := Stress(w, r, opt)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, Stress(w, r, opt))
 }
 
 func TestStressDuplexNetPipe(t *testing.T) {
@@ -31,10 +30,7 @@ func TestStressDuplexNetPipe(t *testing.T) {
 		MsgCount: 100,
 	}
 
-	err := StressDuplex(ca, cb, opt)
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, StressDuplex(ca, cb, opt))
 }
 
 func BenchmarkPipe(b *testing.B) {
@@ -47,11 +43,5 @@ func BenchmarkPipe(b *testing.B) {
 		MsgCount: b.N,
 	}
 
-	check(Stress(ca, cb, opt))
-}
-
-func check(err error) {
-	if err != nil {
-		panic(err)
-	}
+	assert.NoError(b, Stress(ca, cb, opt))
 }

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -5,9 +5,10 @@ package test
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCheckRoutines(t *testing.T) {
@@ -35,12 +36,8 @@ func TestCheckRoutinesStrict(t *testing.T) {
 	report := CheckRoutinesStrict(mock)
 	defer func() {
 		report()
-		if len(mock.fatalfCalled) == 0 {
-			t.Error("expected Fatalf to be called")
-		}
-		if !strings.Contains(mock.fatalfCalled[0], "Unexpected routines") {
-			t.Error("expected 'Unexpected routines'")
-		}
+		assert.NotEmpty(t, mock.fatalfCalled, "expected Fatalf to be called")
+		assert.Contains(t, mock.fatalfCalled[0], "Unexpected routines")
 	}()
 
 	go func() {

--- a/utils/xor/xor_test.go
+++ b/utils/xor/xor_test.go
@@ -4,11 +4,12 @@
 package xor
 
 import (
-	"bytes"
 	"crypto/rand"
 	"fmt"
 	"io"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestXOR(t *testing.T) { //nolint:cyclop
@@ -25,28 +26,17 @@ func TestXOR(t *testing.T) { //nolint:cyclop
 					d0[j+alignD] = 42
 					d1 := d0[alignD : j+alignD]
 					d2 := make([]byte, j+alignD)[alignD:]
-					if _, err := io.ReadFull(rand.Reader, p); err != nil {
-						t.Fatal(err)
-					}
-					if _, err := io.ReadFull(rand.Reader, q); err != nil {
-						t.Fatal(err)
-					}
+					_, err := io.ReadFull(rand.Reader, p)
+					assert.NoError(t, err)
+					_, err = io.ReadFull(rand.Reader, q)
+					assert.NoError(t, err)
 					XorBytes(d1, p, q)
 					n := minInt(p, q)
 					for i := 0; i < n; i++ {
 						d2[i] = p[i] ^ q[i]
 					}
-					if !bytes.Equal(d1, d2) {
-						t.Errorf(
-							"p: %#v, q: %#v, "+
-								"expect: %#v, "+
-								"result: %#v",
-							p, q, d2, d1,
-						)
-					}
-					if d0[j+alignD] != 42 {
-						t.Error("guard overwritten")
-					}
+					assert.Equalf(t, d1, d2, "p: %#v, q: %#v", p, q)
+					assert.Equal(t, byte(42), d0[j+alignD], "guard overwritten")
 				}
 			}
 		}

--- a/vnet/conn_map_test.go
+++ b/vnet/conn_map_test.go
@@ -46,7 +46,7 @@ func TestUDPConnMap(t *testing.T) {
 
 		err = connMap.delete(connIn.LocalAddr())
 		assert.NoError(t, err, "should succeed")
-		assert.Equal(t, 0, len(connMap.portMap), "should match")
+		assert.Empty(t, connMap.portMap, "should match")
 
 		err = connMap.delete(connIn.LocalAddr())
 		assert.Error(t, err, "should fail")

--- a/vnet/loss_filter.go
+++ b/vnet/loss_filter.go
@@ -23,6 +23,7 @@ func NewLossFilter(nic NIC, chance int) (*LossFilter, error) {
 		NIC:    nic,
 		chance: chance,
 	}
+	//nolint:staticcheck
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	return f, nil

--- a/vnet/nat_test.go
+++ b/vnet/nat_test.go
@@ -660,8 +660,8 @@ func TestNATMappingTimeout(t *testing.T) {
 
 		_, err = nat.translateInbound(iec)
 		assert.NotNil(t, err, "should drop")
-		assert.Equal(t, 0, len(nat.outboundMap), "should have no binding")
-		assert.Equal(t, 0, len(nat.inboundMap), "should have no binding")
+		assert.Empty(t, nat.outboundMap, "should have no binding")
+		assert.Empty(t, nat.inboundMap, "should have no binding")
 	})
 }
 
@@ -695,8 +695,8 @@ func TestNAT1To1Behavior(t *testing.T) {
 
 		oec, err := nat.translateOutbound(oic)
 		assert.Nil(t, err, "should succeed")
-		assert.Equal(t, 0, len(nat.outboundMap), "should match")
-		assert.Equal(t, 0, len(nat.inboundMap), "should match")
+		assert.Empty(t, nat.outboundMap, "should match")
+		assert.Empty(t, nat.inboundMap, "should match")
 
 		log.Debugf("o-original  : %s", oic.String())
 		log.Debugf("o-translated: %s", oec.String())

--- a/vnet/net_test.go
+++ b/vnet/net_test.go
@@ -305,7 +305,7 @@ func TestNetVirtual(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 
 		assert.Equal(t, 1, nw.udpConns.size(), "should match")
 		assert.NoError(t, conn.Close(), "should succeed")
-		assert.Equal(t, 0, nw.udpConns.size(), "should match")
+		assert.Empty(t, nw.udpConns.size(), "should match")
 	})
 
 	t.Run("ListenPacket random port", func(t *testing.T) {
@@ -322,7 +322,7 @@ func TestNetVirtual(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 
 		assert.Equal(t, 1, nw.udpConns.size(), "should match")
 		assert.NoError(t, conn.Close(), "should succeed")
-		assert.Equal(t, 0, nw.udpConns.size(), "should match")
+		assert.Empty(t, nw.udpConns.size(), "should match")
 	})
 
 	t.Run("ListenPacket specific port", func(t *testing.T) {
@@ -339,7 +339,7 @@ func TestNetVirtual(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 
 		assert.Equal(t, 1, nw.udpConns.size(), "should match")
 		assert.NoError(t, conn.Close(), "should succeed")
-		assert.Equal(t, 0, nw.udpConns.size(), "should match")
+		assert.Empty(t, nw.udpConns.size(), "should match")
 	})
 
 	t.Run("ListenUDP random port", func(t *testing.T) {
@@ -359,7 +359,7 @@ func TestNetVirtual(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 
 		assert.Equal(t, 1, nw.udpConns.size(), "should match")
 		assert.NoError(t, conn.Close(), "should succeed")
-		assert.Equal(t, 0, nw.udpConns.size(), "should match")
+		assert.Empty(t, nw.udpConns.size(), "should match")
 	})
 
 	t.Run("ListenUDP specific port", func(t *testing.T) {
@@ -380,7 +380,7 @@ func TestNetVirtual(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 
 		assert.Equal(t, 1, nw.udpConns.size(), "should match")
 		assert.NoError(t, conn.Close(), "should succeed")
-		assert.Equal(t, 0, nw.udpConns.size(), "should match")
+		assert.Empty(t, nw.udpConns.size(), "should match")
 	})
 
 	t.Run("Dial (UDP) lo0", func(t *testing.T) {
@@ -403,7 +403,7 @@ func TestNetVirtual(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		assert.Equal(t, "127.0.0.1:1234", raddr.String(), "should match")
 		assert.Equal(t, 1, nw.udpConns.size(), "should match")
 		assert.NoError(t, conn.Close(), "should succeed")
-		assert.Equal(t, 0, nw.udpConns.size(), "should match")
+		assert.Empty(t, nw.udpConns.size(), "should match")
 	})
 
 	t.Run("Dial (UDP) eth0", func(t *testing.T) {
@@ -434,7 +434,7 @@ func TestNetVirtual(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		assert.Equal(t, "27.3.4.5:1234", raddr.String(), "should match")
 		assert.Equal(t, 1, nw.udpConns.size(), "should match")
 		assert.NoError(t, conn.Close(), "should succeed")
-		assert.Equal(t, 0, nw.udpConns.size(), "should match")
+		assert.Empty(t, nw.udpConns.size(), "should match")
 	})
 
 	t.Run("DialUDP", func(t *testing.T) {
@@ -467,7 +467,7 @@ func TestNetVirtual(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		assert.Equal(t, "127.0.0.1:1234", raddr.String(), "should match")
 		assert.Equal(t, 1, nw.udpConns.size(), "should match")
 		assert.NoError(t, conn.Close(), "should succeed")
-		assert.Equal(t, 0, nw.udpConns.size(), "should match")
+		assert.Empty(t, nw.udpConns.size(), "should match")
 	})
 
 	t.Run("Resolver", func(t *testing.T) {
@@ -503,7 +503,7 @@ func TestNetVirtual(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		assert.Equal(t, "30.31.32.33:1234", raddr.String(), "should match")
 		assert.Equal(t, 1, nw.udpConns.size(), "should match")
 		assert.NoError(t, conn.Close(), "should succeed")
-		assert.Equal(t, 0, nw.udpConns.size(), "should match")
+		assert.Empty(t, nw.udpConns.size(), "should match")
 	})
 
 	t.Run("Loopback", func(t *testing.T) {
@@ -567,7 +567,7 @@ func TestNetVirtual(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			}
 		}
 
-		assert.Equal(t, 0, nw.udpConns.size(), "should match")
+		assert.Empty(t, nw.udpConns.size(), "should match")
 		assert.True(t, hasReceived, "should have received data")
 	})
 
@@ -707,7 +707,7 @@ func TestNetVirtual(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 		assert.Equal(t, "127.0.0.1:1234", raddr.String(), "should match")
 		assert.Equal(t, 1, nw.udpConns.size(), "should match")
 		assert.NoError(t, conn.Close(), "should succeed")
-		assert.Equal(t, 0, nw.udpConns.size(), "should match")
+		assert.Empty(t, nw.udpConns.size(), "should match")
 	})
 
 	t.Run("Two IPs on a NIC", func(t *testing.T) {

--- a/vnet/udpproxy_direct_test.go
+++ b/vnet/udpproxy_direct_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
+	"github.com/stretchr/testify/assert"
 )
 
 // The vnet client:
@@ -32,9 +33,9 @@ func TestUDPProxyDirectDeliverTypical(t *testing.T) { //nolint:cyclop
 
 	var r0, r1, r2 error
 	defer func() {
-		if r0 != nil || r1 != nil || r2 != nil {
-			t.Errorf("fail for ctx=%v, r0=%v, r1=%v, r2=%v", ctx.Err(), r0, r1, r2)
-		}
+		assert.NoErrorf(t, r0, "fail for ctx=%v, r0=%v", ctx.Err(), r0)
+		assert.NoErrorf(t, r1, "fail for ctx=%v, r1=%v", ctx.Err(), r1)
+		assert.NoErrorf(t, r2, "fail for ctx=%v, r2=%v", ctx.Err(), r2)
 	}()
 
 	var wg sync.WaitGroup
@@ -187,9 +188,9 @@ func TestUDPProxyDirectDeliverBadCase(t *testing.T) { //nolint:cyclop
 
 	var r0, r1, r2 error
 	defer func() {
-		if r0 != nil || r1 != nil || r2 != nil {
-			t.Errorf("fail for ctx=%v, r0=%v, r1=%v, r2=%v", ctx.Err(), r0, r1, r2)
-		}
+		assert.NoErrorf(t, r0, "fail for ctx=%v, r0=%v", ctx.Err(), r0)
+		assert.NoErrorf(t, r1, "fail for ctx=%v, r1=%v", ctx.Err(), r1)
+		assert.NoErrorf(t, r2, "fail for ctx=%v, r2=%v", ctx.Err(), r2)
 	}()
 
 	var wg sync.WaitGroup

--- a/vnet/udpproxy_test.go
+++ b/vnet/udpproxy_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/pion/logging"
+	"github.com/stretchr/testify/assert"
 )
 
 type MockUDPEchoServer struct {
@@ -92,7 +93,7 @@ var testTimeout = flag.Int("timeout", 5000, "For each case, the timeout in ms") 
 
 func TestMain(m *testing.M) {
 	flag.Parse()
-	os.Exit(m.Run())
+	os.Exit(m.Run()) //nolint:forbidigo
 }
 
 // vnet client:
@@ -109,9 +110,9 @@ func TestUDPProxyOne2One(t *testing.T) { //nolint:gocyclo,cyclop
 
 	var r0, r1, r2 error
 	defer func() {
-		if r0 != nil || r1 != nil || r2 != nil {
-			t.Errorf("fail for ctx=%v, r0=%v, r1=%v, r2=%v", ctx.Err(), r0, r1, r2)
-		}
+		assert.NoErrorf(t, r0, "fail for ctx=%v, r0=%v", ctx.Err(), r0)
+		assert.NoErrorf(t, r1, "fail for ctx=%v, r1=%v", ctx.Err(), r1)
+		assert.NoErrorf(t, r2, "fail for ctx=%v, r2=%v", ctx.Err(), r2)
 	}()
 
 	var wg sync.WaitGroup
@@ -263,9 +264,10 @@ func TestUDPProxyTwo2One(t *testing.T) { //nolint:gocyclo,cyclop
 
 	var r0, r1, r2, r3 error
 	defer func() {
-		if r0 != nil || r1 != nil || r2 != nil || r3 != nil {
-			t.Errorf("fail for ctx=%v, r0=%v, r1=%v, r2=%v, r3=%v", ctx.Err(), r0, r1, r2, r3)
-		}
+		assert.NoErrorf(t, r0, "fail for ctx=%v, r0=%v", ctx.Err(), r0)
+		assert.NoErrorf(t, r1, "fail for ctx=%v, r1=%v", ctx.Err(), r1)
+		assert.NoErrorf(t, r2, "fail for ctx=%v, r2=%v", ctx.Err(), r2)
+		assert.NoErrorf(t, r3, "fail for ctx=%v, r3=%v", ctx.Err(), r3)
 	}()
 
 	var wg sync.WaitGroup
@@ -452,9 +454,10 @@ func TestUDPProxyProxyTwice(t *testing.T) { //nolint:gocyclo,cyclop
 
 	var r0, r1, r2, r3 error
 	defer func() {
-		if r0 != nil || r1 != nil || r2 != nil || r3 != nil {
-			t.Errorf("fail for ctx=%v, r0=%v, r1=%v, r2=%v, r3=%v", ctx.Err(), r0, r1, r2, r3)
-		}
+		assert.NoErrorf(t, r0, "fail for ctx=%v, r0=%v", ctx.Err(), r0)
+		assert.NoErrorf(t, r1, "fail for ctx=%v, r1=%v", ctx.Err(), r1)
+		assert.NoErrorf(t, r2, "fail for ctx=%v, r2=%v", ctx.Err(), r2)
+		assert.NoErrorf(t, r3, "fail for ctx=%v, r3=%v", ctx.Err(), r3)
 	}()
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
#### Description
Use testify's assert package instead of the standard library's testing package.

#### Reference issue
https://github.com/pion/.goassets/pull/222
