### PR TITLE
Handle replay after wrapping in replaydetector

### DIFF
--- a/replaydetector/replaydetector.go
+++ b/replaydetector/replaydetector.go
@@ -126,8 +126,10 @@ func (d *wrappedSlidingWindowDetector) Check(seq uint64) (func() bool, bool) {
 			d.mask.Lsh(uint(-diff))
 			d.latestSeq = seq
 			latest = true
+			d.mask.SetBit(0)
+		} else {
+			d.mask.SetBit(uint(diff))
 		}
-		d.mask.SetBit(uint(d.latestSeq - seq))
 
 		return latest
 	}, true

--- a/replaydetector/replaydetector_test.go
+++ b/replaydetector/replaydetector_test.go
@@ -243,6 +243,17 @@ func TestReplayDetectorWrapped(t *testing.T) {
 			},
 			[]uint64{0xFFFD, 0xFFFC, 0x0002, 0xFFFE, 0x0000, 0x0001, 0xFFFF, 0x0003},
 		},
+		"BeforeWrapReplayed": {
+			64, 0xFFFF,
+			[]uint64{0x0, 0xFFFF, 0xFFFF},
+			[]bool{
+				true, true, false,
+			},
+			[]bool{
+				true, false, false,
+			},
+			[]uint64{0x0, 0xFFFF},
+		},
 	}
 	for name, c := range commonCases {
 		_, ok := cases[name]


### PR DESCRIPTION
#### Description
Fixes the accept() callback of wrappedSlidingWindowDetector to update mask correctly when the sequence number wraps between seq and latestSeq. Without this fix some packets that should be blocked may be let through around sequence number wrap arounds, as demonstrated by the added test case.