### PR TITLE
Add dynamic loss and delay filters with runtime controls

### DIFF
--- a/vnet/delay_filter.go
+++ b/vnet/delay_filter.go
@@ -4,6 +4,7 @@
 package vnet
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -27,23 +28,23 @@ type timedChunk struct {
 
 // NewDelayFilter creates and starts a new DelayFilter with the given nic and delay.
 func NewDelayFilter(nic NIC, delay time.Duration) (*DelayFilter, error) {
-	f := &DelayFilter{
+	delayFilter := &DelayFilter{
 		NIC:   nic,
 		push:  make(chan struct{}),
 		queue: newChunkQueue(0, 0),
 		done:  make(chan struct{}),
 	}
 
-	f.delay.Store(int64(delay))
+	delayFilter.delay.Store(int64(delay))
 
 	// Start processing automatically
-	f.wg.Add(1)
-	go f.run()
+	delayFilter.wg.Add(1)
+	go delayFilter.run()
 
-	return f, nil
+	return delayFilter, nil
 }
 
-// SetDelay atomically updates the delay
+// SetDelay atomically updates the delay.
 func (f *DelayFilter) SetDelay(newDelay time.Duration) {
 	f.delay.Store(int64(newDelay))
 }
@@ -70,60 +71,83 @@ func (f *DelayFilter) run() {
 	for {
 		select {
 		case <-f.done:
-			// Drain remaining packets immediately on shutdown
-			for {
-				next, ok := f.queue.pop()
-				if !ok {
-					break
-				}
-				if timedChunk, ok := next.(timedChunk); ok {
-					f.NIC.onInboundChunk(timedChunk.Chunk)
-				}
-			}
+			f.drainRemainingPackets()
+
 			return
 
 		case <-f.push:
-			// New packet arrived, update timer for next deadline
-			next := f.queue.peek()
-			if next != nil {
-				if timedChunk, ok := next.(timedChunk); ok {
-					if !timer.Stop() {
-						<-timer.C
-					}
-					timer.Reset(time.Until(timedChunk.deadline))
-				}
-			}
+			f.updateTimerForNextPacket(timer)
 
 		case now := <-timer.C:
-			// Process all ready packets
-			for {
-				next := f.queue.peek()
-				if next == nil {
-					break
-				}
-
-				if timedChunk, ok := next.(timedChunk); ok && timedChunk.deadline.Before(now) {
-					_, _ = f.queue.pop() // We already have the item from peek()
-					f.NIC.onInboundChunk(timedChunk.Chunk)
-				} else {
-					break
-				}
-			}
-
-			// Schedule timer for next packet
-			next := f.queue.peek()
-			if next == nil {
-				timer.Reset(time.Minute) // Long timeout when queue is empty
-			} else if timedChunk, ok := next.(timedChunk); ok {
-				timer.Reset(time.Until(timedChunk.deadline))
-			}
+			f.processReadyPackets(now)
+			f.scheduleNextPacketTimer(timer)
 		}
 	}
+}
+
+// drainRemainingPackets sends all remaining packets immediately during shutdown.
+func (f *DelayFilter) drainRemainingPackets() {
+	for {
+		next, ok := f.queue.pop()
+		if !ok {
+			break
+		}
+		if chunk, ok := next.(timedChunk); ok {
+			f.NIC.onInboundChunk(chunk.Chunk)
+		}
+	}
+}
+
+// updateTimerForNextPacket updates the timer when a new packet arrives.
+func (f *DelayFilter) updateTimerForNextPacket(timer *time.Timer) {
+	next := f.queue.peek()
+	if next != nil {
+		if chunk, ok := next.(timedChunk); ok {
+			if !timer.Stop() {
+				<-timer.C
+			}
+			timer.Reset(time.Until(chunk.deadline))
+		}
+	}
+}
+
+// processReadyPackets processes all packets that are ready to be sent.
+func (f *DelayFilter) processReadyPackets(now time.Time) {
+	for {
+		next := f.queue.peek()
+		if next == nil {
+			break
+		}
+
+		if chunk, ok := next.(timedChunk); ok && chunk.deadline.Before(now) {
+			_, _ = f.queue.pop() // We already have the item from peek()
+			f.NIC.onInboundChunk(chunk.Chunk)
+		} else {
+			break
+		}
+	}
+}
+
+// scheduleNextPacketTimer schedules the timer for the next packet to be processed.
+func (f *DelayFilter) scheduleNextPacketTimer(timer *time.Timer) {
+	next := f.queue.peek()
+	if next == nil {
+		timer.Reset(time.Minute) // Long timeout when queue is empty
+	} else if chunk, ok := next.(timedChunk); ok {
+		timer.Reset(time.Until(chunk.deadline))
+	}
+}
+
+// Run is provided for backward compatibility. The DelayFilter now starts
+// automatically when created, so this method is a no-op.
+func (f *DelayFilter) Run(_ context.Context) {
+	// DelayFilter now starts automatically in NewDelayFilter, so this is a no-op
 }
 
 // Close stops the DelayFilter and waits for graceful shutdown.
 func (f *DelayFilter) Close() error {
 	close(f.done)
 	f.wg.Wait()
+
 	return nil
 }

--- a/vnet/delay_filter.go
+++ b/vnet/delay_filter.go
@@ -4,17 +4,20 @@
 package vnet
 
 import (
-	"context"
+	"sync"
+	"sync/atomic"
 	"time"
 )
 
-// DelayFilter delays outgoing packets by the given delay. Run must be called
-// before any packets will be forwarded.
+// DelayFilter delays inbound packets by the given delay. Automatically starts
+// processing when created and runs until Close() is called.
 type DelayFilter struct {
 	NIC
-	delay time.Duration
+	delay atomic.Int64 // atomic field - stores time.Duration as int64
 	push  chan struct{}
 	queue *chunkQueue
+	done  chan struct{}
+	wg    sync.WaitGroup
 }
 
 type timedChunk struct {
@@ -22,59 +25,105 @@ type timedChunk struct {
 	deadline time.Time
 }
 
-// NewDelayFilter creates a new DelayFilter with the given nic and delay.
+// NewDelayFilter creates and starts a new DelayFilter with the given nic and delay.
 func NewDelayFilter(nic NIC, delay time.Duration) (*DelayFilter, error) {
-	return &DelayFilter{
+	f := &DelayFilter{
 		NIC:   nic,
-		delay: delay,
 		push:  make(chan struct{}),
 		queue: newChunkQueue(0, 0),
-	}, nil
+		done:  make(chan struct{}),
+	}
+
+	f.delay.Store(int64(delay))
+
+	// Start processing automatically
+	f.wg.Add(1)
+	go f.run()
+
+	return f, nil
+}
+
+// SetDelay atomically updates the delay
+func (f *DelayFilter) SetDelay(newDelay time.Duration) {
+	f.delay.Store(int64(newDelay))
+}
+
+func (f *DelayFilter) getDelay() time.Duration {
+	return time.Duration(f.delay.Load())
 }
 
 func (f *DelayFilter) onInboundChunk(c Chunk) {
 	f.queue.push(timedChunk{
 		Chunk:    c,
-		deadline: time.Now().Add(f.delay),
+		deadline: time.Now().Add(f.getDelay()),
 	})
 	f.push <- struct{}{}
 }
 
-// Run starts forwarding of packets. Packets will be forwarded if they spent
-// >delay time in the internal queue. Must be called before any packet will be
-// forwarded.
-func (f *DelayFilter) Run(ctx context.Context) { //nolint:cyclop
+// run processes the delayed packets queue until Close() is called.
+func (f *DelayFilter) run() {
+	defer f.wg.Done()
+
 	timer := time.NewTimer(0)
+	defer timer.Stop()
+
 	for {
 		select {
-		case <-ctx.Done():
-			return
-		case <-f.push:
-			next := f.queue.peek().(timedChunk) //nolint:forcetypeassert
-			if !timer.Stop() {
-				<-timer.C
+		case <-f.done:
+			// Drain remaining packets immediately on shutdown
+			for {
+				next, ok := f.queue.pop()
+				if !ok {
+					break
+				}
+				if timedChunk, ok := next.(timedChunk); ok {
+					f.NIC.onInboundChunk(timedChunk.Chunk)
+				}
 			}
-			timer.Reset(time.Until(next.deadline))
+			return
+
+		case <-f.push:
+			// New packet arrived, update timer for next deadline
+			next := f.queue.peek()
+			if next != nil {
+				if timedChunk, ok := next.(timedChunk); ok {
+					if !timer.Stop() {
+						<-timer.C
+					}
+					timer.Reset(time.Until(timedChunk.deadline))
+				}
+			}
+
 		case now := <-timer.C:
+			// Process all ready packets
+			for {
+				next := f.queue.peek()
+				if next == nil {
+					break
+				}
+
+				if timedChunk, ok := next.(timedChunk); ok && timedChunk.deadline.Before(now) {
+					_, _ = f.queue.pop() // We already have the item from peek()
+					f.NIC.onInboundChunk(timedChunk.Chunk)
+				} else {
+					break
+				}
+			}
+
+			// Schedule timer for next packet
 			next := f.queue.peek()
 			if next == nil {
-				timer.Reset(time.Minute)
-
-				continue
-			}
-			if n, ok := next.(timedChunk); ok && n.deadline.Before(now) {
-				f.queue.pop() // ignore result because we already got and casted it from peek
-				f.NIC.onInboundChunk(n.Chunk)
-			}
-			next = f.queue.peek()
-			if next == nil {
-				timer.Reset(time.Minute)
-
-				continue
-			}
-			if n, ok := next.(timedChunk); ok {
-				timer.Reset(time.Until(n.deadline))
+				timer.Reset(time.Minute) // Long timeout when queue is empty
+			} else if timedChunk, ok := next.(timedChunk); ok {
+				timer.Reset(time.Until(timedChunk.deadline))
 			}
 		}
 	}
+}
+
+// Close stops the DelayFilter and waits for graceful shutdown.
+func (f *DelayFilter) Close() error {
+	close(f.done)
+	f.wg.Wait()
+	return nil
 }

--- a/vnet/delay_filter_test.go
+++ b/vnet/delay_filter_test.go
@@ -4,103 +4,157 @@
 package vnet
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
+type TimestampedChunk struct {
+	ts time.Time
+	c  Chunk
+}
+
+func initTest(t *testing.T) (*DelayFilter, chan TimestampedChunk) {
+	t.Helper()
+	nic := newMockNIC(t)
+	df, err := NewDelayFilter(nic, 0)
+	if !assert.NoError(t, err, "should succeed") {
+		return nil, nil
+	}
+
+	receiveCh := make(chan TimestampedChunk)
+
+	nic.mockOnInboundChunk = func(c Chunk) {
+		receivedAt := time.Now()
+		receiveCh <- TimestampedChunk{
+			ts: receivedAt,
+			c:  c,
+		}
+	}
+
+	return df, receiveCh
+}
+
+func scheduleOnePacketAtATime(t *testing.T, df *DelayFilter, receiveCh chan TimestampedChunk, delay time.Duration, nrPackets int) {
+	t.Helper()
+	df.SetDelay(delay)
+	lastNr := -1
+	for i := 0; i < nrPackets; i++ {
+		sent := time.Now()
+		df.onInboundChunk(&chunkUDP{
+			chunkIP:  chunkIP{timestamp: sent},
+			userData: []byte{byte(i)},
+		})
+
+		select {
+		case c := <-receiveCh:
+			nr := int(c.c.UserData()[0])
+
+			assert.Greater(t, nr, lastNr)
+			lastNr = nr
+
+			assert.Greater(t, c.ts.Sub(sent), delay)
+			assert.Less(t, c.ts.Sub(sent), delay+10*time.Millisecond)
+		case <-time.After(time.Second):
+			assert.Fail(t, "expected to receive next chunk")
+		}
+	}
+}
+
+func scheduleManyPackets(t *testing.T, df *DelayFilter, receiveCh chan TimestampedChunk, delay time.Duration, nrPackets int) {
+	t.Helper()
+	df.SetDelay(delay)
+	sent := time.Now()
+
+	for i := 0; i < nrPackets; i++ {
+		df.onInboundChunk(&chunkUDP{
+			chunkIP:  chunkIP{timestamp: sent},
+			userData: []byte{byte(i)},
+		})
+	}
+
+	// receive nrPackets chunks with a minimum delay
+	for i := 0; i < nrPackets; i++ {
+		select {
+		case c := <-receiveCh:
+			nr := int(c.c.UserData()[0])
+			assert.Equal(t, i, nr)
+			assert.Greater(t, c.ts.Sub(sent), delay)
+			assert.Less(t, c.ts.Sub(sent), delay+10*time.Millisecond)
+		case <-time.After(time.Second):
+			assert.Fail(t, "expected to receive next chunk")
+		}
+	}
+}
+
 func TestDelayFilter(t *testing.T) {
 	t.Run("schedulesOnePacketAtATime", func(t *testing.T) {
-		nic := newMockNIC(t)
-		df, err := NewDelayFilter(nic, 10*time.Millisecond)
-		if !assert.NoError(t, err, "should succeed") {
+		df, receiveCh := initTest(t)
+		if df == nil {
 			return
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		go df.Run(ctx)
-
-		type TimestampedChunk struct {
-			ts time.Time
-			c  Chunk
-		}
-		receiveCh := make(chan TimestampedChunk)
-		nic.mockOnInboundChunk = func(c Chunk) {
-			receivedAt := time.Now()
-			receiveCh <- TimestampedChunk{
-				ts: receivedAt,
-				c:  c,
-			}
-		}
-
-		lastNr := -1
-		for i := 0; i < 100; i++ {
-			sent := time.Now()
-			df.onInboundChunk(&chunkUDP{
-				chunkIP:  chunkIP{timestamp: sent},
-				userData: []byte{byte(i)},
-			})
-
-			select {
-			case c := <-receiveCh:
-				nr := int(c.c.UserData()[0])
-
-				assert.Greater(t, nr, lastNr)
-				lastNr = nr
-
-				assert.Greater(t, c.ts.Sub(sent), 10*time.Millisecond)
-			case <-time.After(time.Second):
-				assert.Fail(t, "expected to receive next chunk")
-			}
-		}
+		scheduleOnePacketAtATime(t, df, receiveCh, 10*time.Millisecond, 100)
+		assert.NoError(t, df.Close())
 	})
 
 	t.Run("schedulesSubsequentManyPackets", func(t *testing.T) {
-		nic := newMockNIC(t)
-		df, err := NewDelayFilter(nic, 10*time.Millisecond)
-		if !assert.NoError(t, err, "should succeed") {
+		df, receiveCh := initTest(t)
+		if df == nil {
 			return
 		}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		go df.Run(ctx)
-
-		type TimestampedChunk struct {
-			ts time.Time
-			c  Chunk
-		}
-		receiveCh := make(chan TimestampedChunk)
-		nic.mockOnInboundChunk = func(c Chunk) {
-			receivedAt := time.Now()
-			receiveCh <- TimestampedChunk{
-				ts: receivedAt,
-				c:  c,
-			}
-		}
-
-		// schedule 100 chunks
-		sent := time.Now()
-		for i := 0; i < 100; i++ {
-			df.onInboundChunk(&chunkUDP{
-				chunkIP:  chunkIP{timestamp: sent},
-				userData: []byte{byte(i)},
-			})
-		}
-
-		// receive 100 chunks with delay>10ms
-		for i := 0; i < 100; i++ {
-			select {
-			case c := <-receiveCh:
-				nr := int(c.c.UserData()[0])
-				assert.Equal(t, i, nr)
-				assert.Greater(t, c.ts.Sub(sent), 10*time.Millisecond)
-			case <-time.After(time.Second):
-				assert.Fail(t, "expected to receive next chunk")
-			}
-		}
+		scheduleManyPackets(t, df, receiveCh, 10*time.Millisecond, 100)
+		assert.NoError(t, df.Close())
 	})
+
+	t.Run("scheduleIncreasingDelayOnePacketAtATime", func(t *testing.T) {
+		df, receiveCh := initTest(t)
+		if df == nil {
+			return
+		}
+
+		scheduleOnePacketAtATime(t, df, receiveCh, 10*time.Millisecond, 10)
+		scheduleOnePacketAtATime(t, df, receiveCh, 50*time.Millisecond, 10)
+		scheduleOnePacketAtATime(t, df, receiveCh, 100*time.Millisecond, 10)
+		assert.NoError(t, df.Close())
+	})
+
+	t.Run("scheduleDecreasingDelayOnePacketAtATime", func(t *testing.T) {
+		df, receiveCh := initTest(t)
+		if df == nil {
+			return
+		}
+
+		scheduleOnePacketAtATime(t, df, receiveCh, 100*time.Millisecond, 10)
+		scheduleOnePacketAtATime(t, df, receiveCh, 50*time.Millisecond, 10)
+		scheduleOnePacketAtATime(t, df, receiveCh, 10*time.Millisecond, 10)
+		assert.NoError(t, df.Close())
+	})
+
+	t.Run("scheduleIncreasingDelayManyPackets", func(t *testing.T) {
+		df, receiveCh := initTest(t)
+		if df == nil {
+			return
+		}
+
+		scheduleManyPackets(t, df, receiveCh, 10*time.Millisecond, 100)
+		scheduleManyPackets(t, df, receiveCh, 50*time.Millisecond, 100)
+		scheduleManyPackets(t, df, receiveCh, 100*time.Millisecond, 100)
+		assert.NoError(t, df.Close())
+	})
+
+	t.Run("scheduleDecreasingDelayManyPackets", func(t *testing.T) {
+		df, receiveCh := initTest(t)
+		if df == nil {
+			return
+		}
+
+		scheduleManyPackets(t, df, receiveCh, 100*time.Millisecond, 100)
+		scheduleManyPackets(t, df, receiveCh, 50*time.Millisecond, 100)
+		scheduleManyPackets(t, df, receiveCh, 10*time.Millisecond, 100)
+		assert.NoError(t, df.Close())
+	})
+
 }

--- a/vnet/loss_filter.go
+++ b/vnet/loss_filter.go
@@ -4,35 +4,193 @@
 package vnet
 
 import (
+	"fmt"
 	"math/rand"
+	"sync"
 	"time"
 )
+
+type LossFilterHandler interface {
+	shouldDrop() bool
+	setLossRate(chance int, resetImmediately bool)
+}
 
 // LossFilter is a wrapper around NICs, that drops some of the packets passed to
 // onInboundChunk.
 type LossFilter struct {
 	NIC
+	LossFilterHandler
+}
+
+// RandomLossHandler drops packets randomly with a probability determined by the chance parameter.
+type RandomLossHandler struct {
 	chance int
+	mutex  sync.RWMutex
+}
+
+// NewRandomLossHandler creates a new RandomLossHandler with the given drop chance.
+func NewRandomLossHandler(chance int) (*RandomLossHandler, error) {
+	if !validateChance(chance) {
+		return nil, fmt.Errorf("chance must be between 0 and 100 inclusive")
+	}
+
+	return &RandomLossHandler{
+		chance: chance,
+	}, nil
+}
+
+func (r *RandomLossHandler) shouldDrop() bool {
+	r.mutex.RLock()
+	chance := r.chance
+	r.mutex.RUnlock()
+	return rand.Intn(100) < chance
+}
+
+func (r *RandomLossHandler) setLossRate(chance int, resetImmediately bool) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	r.chance = chance
+}
+
+// RandomShuffleLossHandler drops packets with a deterministic probability for every 100 packets
+// That is, for every 100 packets, it guarentees that the number of packets dropped is equal to the chance parameter.
+type RandomShuffleLossHandler struct {
+	blockIdx      int
+	shuffledBlock []bool
+	currentChance int
+	pendingChance int
+	mutex         sync.Mutex
+}
+
+// NewRandomShuffleLossHandler creates a new RandomShuffleLossHandler with the given drop chance and shuffle block size.
+// The default shuffle block size should be 100.
+func NewRandomShuffleLossHandler(chance int, shuffleBlockSize int) (*RandomShuffleLossHandler, error) {
+
+	if !validateChance(chance) {
+		return nil, fmt.Errorf("chance must be between 0 and 100 inclusive")
+	}
+
+	if shuffleBlockSize < 1 {
+		return nil, fmt.Errorf("shuffleBlockSize must be greater than 0")
+	}
+
+	filter := RandomShuffleLossHandler{
+		shuffledBlock: make([]bool, shuffleBlockSize),
+		blockIdx:      0,
+		currentChance: chance,
+		pendingChance: chance,
+	}
+
+	for i := 0; i < filter.currentChance; i++ {
+		filter.shuffledBlock[i] = true
+	}
+
+	filter.shuffleBlock()
+	return &filter, nil
+}
+
+func (r *RandomShuffleLossHandler) setLossRate(chance int, resetImmediately bool) {
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	r.pendingChance = chance
+
+	if resetImmediately {
+		r.shuffleBlock()
+	}
+}
+
+func (r *RandomShuffleLossHandler) shuffleBlock() {
+
+	for i := 0; i < len(r.shuffledBlock); i++ {
+		if r.pendingChance == r.currentChance {
+			break
+		} else if r.pendingChance > r.currentChance && !r.shuffledBlock[i] {
+			r.shuffledBlock[i] = true
+			r.currentChance++
+		} else if r.pendingChance < r.currentChance && r.shuffledBlock[i] {
+			r.shuffledBlock[i] = false
+			r.currentChance--
+		}
+	}
+
+	rand.Shuffle(len(r.shuffledBlock), func(i, j int) {
+		r.shuffledBlock[i], r.shuffledBlock[j] = r.shuffledBlock[j], r.shuffledBlock[i]
+	})
+	r.blockIdx = 0
+}
+
+func (r *RandomShuffleLossHandler) shouldDrop() bool {
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if r.blockIdx == len(r.shuffledBlock) {
+		r.shuffleBlock()
+	}
+
+	res := r.shuffledBlock[r.blockIdx]
+	r.blockIdx++
+	return res
 }
 
 // NewLossFilter creates a new LossFilter that drops every packet with a
-// probability of chance/100. Every packet that is not dropped is passed on to
-// the given NIC.
-func NewLossFilter(nic NIC, chance int) (*LossFilter, error) {
+// probability of chance/100 by default. You can provide a custom handler to
+// override the default behavior.
+func NewLossFilter(nic NIC, chance int, handler ...LossFilterHandler) (*LossFilter, error) {
+
+	var lossHandler LossFilterHandler
+	var err error
+
+	if !validateChance(chance) {
+		return nil, fmt.Errorf("chance must be between 0 and 100 inclusive")
+	}
+
+	if len(handler) > 0 {
+		lossHandler = handler[0]
+	} else {
+		lossHandler, err = NewRandomLossHandler(chance)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	f := &LossFilter{
-		NIC:    nic,
-		chance: chance,
+		NIC:               nic,
+		LossFilterHandler: lossHandler,
 	}
 	//nolint:staticcheck
 	rand.Seed(time.Now().UTC().UnixNano())
 
+	f.LossFilterHandler.setLossRate(chance, false)
 	return f, nil
 }
 
 func (f *LossFilter) onInboundChunk(c Chunk) {
-	if rand.Intn(100) < f.chance { //nolint:gosec
+
+	if f.LossFilterHandler.shouldDrop() {
 		return
 	}
 
 	f.NIC.onInboundChunk(c)
+}
+
+// SetLossRate sets the loss rate for the loss filter.
+// The chance parameter is an integer out of 100.
+// The resetImmediately parameter is a boolean that indicates whether to reset the loss rate immediately.
+// If resetImmediately is true, the loss rate will be reset immediately.
+// If resetImmediately is false, the loss rate will be reset after the next shuffle for RandomShuffleLossHandler
+// Note that for random loss handler, the loss rate will be reset immediately regardless of the resetImmediately parameter.
+func (f *LossFilter) SetLossRate(chance int, resetImmediately bool) error {
+	if !validateChance(chance) {
+		return fmt.Errorf("chance must be between 0 and 100 inclusive")
+	}
+
+	f.LossFilterHandler.setLossRate(chance, resetImmediately)
+	return nil
+}
+
+func validateChance(chance int) bool {
+	return chance >= 0 && chance <= 100
 }

--- a/vnet/loss_filter_test.go
+++ b/vnet/loss_filter_test.go
@@ -60,7 +60,7 @@ func newMockNIC(t *testing.T) *mockNIC {
 }
 
 func TestLossFilter(t *testing.T) {
-	t.Run("FullLoss", func(t *testing.T) {
+	t.Run("FullLossDefaultHandler", func(t *testing.T) {
 		mnic := newMockNIC(t)
 
 		f, err := NewLossFilter(mnic, 100)
@@ -71,7 +71,7 @@ func TestLossFilter(t *testing.T) {
 		f.onInboundChunk(&chunkUDP{})
 	})
 
-	t.Run("NoLoss", func(t *testing.T) {
+	t.Run("NoLossDefaultHandler", func(t *testing.T) {
 		mnic := newMockNIC(t)
 
 		f, err := NewLossFilter(mnic, 0)
@@ -92,7 +92,7 @@ func TestLossFilter(t *testing.T) {
 		assert.Equal(t, packets, received)
 	})
 
-	t.Run("SomeLoss", func(t *testing.T) {
+	t.Run("SomeLossDefaultHandler", func(t *testing.T) {
 		mnic := newMockNIC(t)
 
 		f, err := NewLossFilter(mnic, 50)
@@ -113,5 +113,125 @@ func TestLossFilter(t *testing.T) {
 		// One of the following could technically fail, but very unlikely
 		assert.Less(t, 0, received)
 		assert.Greater(t, packets, received)
+	})
+
+	t.Run("LossRateChangeRandomShuffleHandler", func(t *testing.T) {
+		mnic := newMockNIC(t)
+
+		lossHandler, err := NewRandomShuffleLossHandler(10, 100)
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+
+		f, err := NewLossFilter(mnic, 0, lossHandler)
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+
+		packets := 100
+		received := 0
+		mnic.mockOnInboundChunk = func(Chunk) {
+			received++
+		}
+
+		for i := 0; i < packets; i++ {
+			f.onInboundChunk(&chunkUDP{})
+		}
+
+		assert.Equal(t, 90, received)
+
+		f.SetLossRate(50, true)
+		received = 0
+		for i := 0; i < packets; i++ {
+			f.onInboundChunk(&chunkUDP{})
+		}
+
+		assert.Equal(t, 50, received)
+
+		f.SetLossRate(99, true)
+		received = 0
+		for i := 0; i < packets; i++ {
+			f.onInboundChunk(&chunkUDP{})
+		}
+
+		assert.Equal(t, 1, received)
+	})
+
+	t.Run("ImmediateLossRateChangeRandomShuffleHandler", func(t *testing.T) {
+		mnic := newMockNIC(t)
+
+		lossHandler, err := NewRandomShuffleLossHandler(10, 100)
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+
+		f, err := NewLossFilter(mnic, 0, lossHandler)
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+
+		packets := 100
+		received := 0
+		mnic.mockOnInboundChunk = func(Chunk) {
+			received++
+		}
+
+		// send 50 dummy packets to partially fill shuffle block
+		for i := 0; i < 50; i++ {
+			f.onInboundChunk(&chunkUDP{})
+		}
+
+		// should trigger an immediate shuffle that sets the loss rate to 50%
+		f.SetLossRate(50, true)
+
+		received = 0
+		for i := 0; i < packets; i++ {
+			f.onInboundChunk(&chunkUDP{})
+		}
+
+		assert.Equal(t, 50, received)
+	})
+
+	t.Run("NonImmediateLossRateChangeRandomShuffleHandler", func(t *testing.T) {
+		mnic := newMockNIC(t)
+
+		lossHandler, err := NewRandomShuffleLossHandler(10, 100)
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+
+		f, err := NewLossFilter(mnic, 0, lossHandler)
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+
+		received := 0
+		mnic.mockOnInboundChunk = func(Chunk) {
+			received++
+		}
+
+		// send 50 dummy packets to partially fill shuffle block
+		for i := 0; i < 50; i++ {
+			f.onInboundChunk(&chunkUDP{})
+		}
+
+		f.SetLossRate(100, false)
+
+		// the loss rate should not be changed until the shuffle block is full
+		for i := 0; i < 50; i++ {
+			f.onInboundChunk(&chunkUDP{})
+		}
+
+		assert.Equal(t, 90, received)
+
+		received = 0
+
+		// the new loss rate should be applied to this block
+		for i := 0; i < 100; i++ {
+			f.onInboundChunk(&chunkUDP{})
+		}
+
+		assert.Equal(t, 0, received)
+
 	})
 }


### PR DESCRIPTION
Implement DelayFilter and LossFilter for vnet package to enable dynamic network condition simulation during runtime:

DelayFilter features:
* Atomic delay adjustment with SetDelay() method
* Automatic startup with background processing
* Thread-safe delay changes without blocking
* Graceful shutdown with packet draining

LossFilter features:
* Multiple loss handler strategies (Random, Shuffle)
* Runtime loss rate adjustment with SetLossRate()
* Immediate or gradual rate change options
* Deterministic vs random loss patterns.

## Testing
* Unit tests
