### PR TITLE
Fix infinite loop when current time equals deadline

### DIFF
--- a/vnet/delay_filter.go
+++ b/vnet/delay_filter.go
@@ -118,7 +118,7 @@ func (f *DelayFilter) processReadyPackets(now time.Time) {
 		if next == nil {
 			break
 		}
-		if chunk, ok := next.(timedChunk); ok && (chunk.deadline.Equal(now) || chunk.deadline.Before(now)) {
+		if chunk, ok := next.(timedChunk); ok && !chunk.deadline.After(now) {
 			_, _ = f.queue.pop() // We already have the item from peek()
 			f.NIC.onInboundChunk(chunk.Chunk)
 		} else {


### PR DESCRIPTION
This might not happen in real-world tests, but in synctest, time does not advance if not all goroutines are blocked. But when the deadline equals the timestamp `now`, the timer will be rescheduled to the same time and end up in an infinite loop.