### PR TITLE
Add vnet duplication filter

### DIFF
--- a/vnet/chunk.go
+++ b/vnet/chunk.go
@@ -78,6 +78,7 @@ type chunkIP struct {
 	sourceIP      net.IP
 	destinationIP net.IP
 	tag           string
+	duplicate     bool
 }
 
 func (c *chunkIP) setTimestamp() time.Time {
@@ -100,6 +101,14 @@ func (c *chunkIP) getSourceIP() net.IP {
 
 func (c *chunkIP) Tag() string {
 	return c.tag
+}
+
+func (c *chunkIP) markDuplicate() {
+	c.duplicate = true
+}
+
+func (c *chunkIP) isDuplicate() bool {
+	return c.duplicate
 }
 
 type chunkUDP struct {

--- a/vnet/duplication_filter.go
+++ b/vnet/duplication_filter.go
@@ -1,0 +1,381 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package vnet
+
+import (
+	"errors"
+	"math"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+const (
+	defaultDuplicationBurstMultiplier = 10.0
+	duplicationBucketSize             = time.Millisecond
+)
+
+var (
+	// errInvalidDuplicationProbability indicates the configured duplication probability is outside [0, 1].
+	errInvalidDuplicationProbability = errors.New("duplication probability must be between 0 and 1 inclusive")
+	// errInvalidDuplicationBurstProbability indicates the configured burst probability is outside [0, 1].
+	errInvalidDuplicationBurstProbability = errors.New("duplication burst probability must be between 0 and 1 inclusive")
+	// errInvalidDuplicationBurstMultiplier indicates the configured burst multiplier is invalid.
+	errInvalidDuplicationBurstMultiplier = errors.New("duplication burst multiplier must be at least 1")
+	// errInvalidDuplicationDelayRange indicates the configured delay range is invalid.
+	errInvalidDuplicationDelayRange = errors.New("duplication delay range must satisfy 0 <= min <= max")
+	// errInvalidDuplicationBurstDuration indicates the burst duration is invalid.
+	errInvalidDuplicationBurstDuration = errors.New("duplication burst duration must be non-negative")
+	// errInvalidDuplicationRouter indicates a nil router was provided when constructing the filter.
+	errInvalidDuplicationRouter = errors.New("duplication filter requires a non-nil router reference")
+)
+
+type duplicationConfig struct {
+	prob            float64
+	burstStartProb  float64
+	burstDuration   time.Duration
+	burstMultiplier float64
+	minExtraDelay   time.Duration
+	maxExtraDelay   time.Duration
+	seed            *int64
+}
+
+// DuplicationOption configures a DuplicationFilter.
+type DuplicationOption func(*duplicationConfig) error
+
+// WithDuplicationProbability sets the base duplication probability.
+func WithDuplicationProbability(prob float64) DuplicationOption {
+	return func(cfg *duplicationConfig) error {
+		if prob < 0 || prob > 1 {
+			return errInvalidDuplicationProbability
+		}
+
+		cfg.prob = prob
+
+		return nil
+	}
+}
+
+// WithDuplicationBurstProbability sets the probability that a burst window starts. Bursts are
+// triggered probabilistically per packet when outside a burst window, creating time-based
+// windows of elevated duplication. For deterministic burst cadences, seed the filter and
+// control the burst timing externally.
+func WithDuplicationBurstProbability(prob float64) DuplicationOption {
+	return func(cfg *duplicationConfig) error {
+		if prob < 0 || prob > 1 {
+			return errInvalidDuplicationBurstProbability
+		}
+
+		cfg.burstStartProb = prob
+
+		return nil
+	}
+}
+
+// WithDuplicationBurstDuration configures how long burst mode stays active once triggered.
+func WithDuplicationBurstDuration(duration time.Duration) DuplicationOption {
+	return func(cfg *duplicationConfig) error {
+		if duration < 0 {
+			return errInvalidDuplicationBurstDuration
+		}
+
+		cfg.burstDuration = duration
+
+		return nil
+	}
+}
+
+// WithDuplicationBurstMultiplier adjusts how aggressively probability increases during a burst window.
+func WithDuplicationBurstMultiplier(multiplier float64) DuplicationOption {
+	return func(cfg *duplicationConfig) error {
+		if multiplier < 1 {
+			return errInvalidDuplicationBurstMultiplier
+		}
+
+		cfg.burstMultiplier = multiplier
+
+		return nil
+	}
+}
+
+// WithDuplicationExtraDelay sets the range for additional delay applied to duplicates. The
+// selected delay is uniform across the inclusive range [minDelay, maxDelay].
+func WithDuplicationExtraDelay(minDelay, maxDelay time.Duration) DuplicationOption {
+	return func(cfg *duplicationConfig) error {
+		if minDelay < 0 || maxDelay < 0 || maxDelay < minDelay {
+			return errInvalidDuplicationDelayRange
+		}
+
+		cfg.minExtraDelay = minDelay
+		cfg.maxExtraDelay = maxDelay
+
+		return nil
+	}
+}
+
+// WithDuplicationImmediate is a convenience that configures duplicates to be delivered
+// without any extra delay (equivalent to WithDuplicationExtraDelay(0, 0)).
+func WithDuplicationImmediate() DuplicationOption {
+	return WithDuplicationExtraDelay(0, 0)
+}
+
+// WithDuplicationSeed sets the random seed used by the duplication filter.
+func WithDuplicationSeed(seed int64) DuplicationOption {
+	return func(cfg *duplicationConfig) error {
+		cfg.seed = new(int64)
+		*cfg.seed = seed
+
+		return nil
+	}
+}
+
+// DuplicationFilter duplicates chunks that traverse a router according to the supplied configuration.
+// When chaining with other filters, register duplication ahead of loss or latency filters to better
+// emulate how duplicates typically occur before drop or jitter on real networks.
+//
+// Note: Call Close() to cancel pending delayed duplicates and prevent goroutine leaks when
+// shutting down. Routers do not automatically close registered duplication filters so applications
+// should wire Close() into their lifecycle (e.g., along with Router.Stop()). The filter is safe
+// for concurrent use by multiple goroutines.
+//
+// Note: Duplicates re-enter the router and may be reordered relative to the original if other
+// filters add jitter. Configure minExtraDelay appropriately to maintain ordering guarantees.
+type DuplicationFilter struct {
+	router   *Router
+	cfg      duplicationConfig
+	mu       sync.Mutex
+	rng      *rand.Rand
+	burstEnd time.Time
+	now      func() time.Time
+	timers   map[*time.Timer]struct{}
+	closed   bool
+	// bucketed scheduling to reduce timer churn
+	buckets map[int64]*dupBucket // key: fireAt in UnixNano aligned to duplicationBucketSize
+}
+
+type dupBucket struct {
+	timer  *time.Timer
+	chunks []Chunk
+}
+
+// NewDuplicationFilterWithOptions constructs a new DuplicationFilter bound to the provided router.
+func NewDuplicationFilterWithOptions(router *Router, opts ...DuplicationOption) (*DuplicationFilter, error) {
+	if router == nil {
+		return nil, errInvalidDuplicationRouter
+	}
+
+	cfg := duplicationConfig{burstMultiplier: defaultDuplicationBurstMultiplier}
+
+	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
+		if err := opt(&cfg); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := validateDuplicationConfig(&cfg); err != nil {
+		return nil, err
+	}
+
+	var rng *rand.Rand
+
+	if cfg.seed == nil {
+		// nolint:gosec // weak rand is intended
+		rng = rand.New(rand.NewSource(time.Now().UnixNano()))
+	} else {
+		// nolint:gosec // weak rand is intended
+		rng = rand.New(rand.NewSource(*cfg.seed))
+	}
+
+	return &DuplicationFilter{
+		router:  router,
+		cfg:     cfg,
+		rng:     rng,
+		now:     time.Now,
+		timers:  make(map[*time.Timer]struct{}),
+		buckets: make(map[int64]*dupBucket),
+	}, nil
+}
+
+// ChunkFilter returns a ChunkFilter that can be registered with Router.AddChunkFilter.
+func (f *DuplicationFilter) ChunkFilter() ChunkFilter {
+	return func(c Chunk) bool {
+		if chunkIsDuplicate(c) {
+			return true
+		}
+
+		delay, shouldDup := f.shouldDuplicate()
+		if shouldDup {
+			clone := c.Clone()
+			f.scheduleDuplicate(clone, delay)
+		}
+
+		return true
+	}
+}
+
+func (f *DuplicationFilter) shouldDuplicate() (time.Duration, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.closed {
+		return 0, false
+	}
+
+	now := f.now()
+	probability := f.cfg.prob
+
+	if f.cfg.burstDuration > 0 && f.cfg.burstStartProb > 0 {
+		if now.After(f.burstEnd) {
+			if f.rng.Float64() < f.cfg.burstStartProb {
+				f.burstEnd = now.Add(f.cfg.burstDuration)
+			}
+		}
+
+		if now.Before(f.burstEnd) {
+			probability = math.Min(1.0, probability*f.cfg.burstMultiplier)
+		}
+	}
+
+	if f.rng.Float64() >= probability {
+		return 0, false
+	}
+
+	// compute delay: uniform distribution over [min, max].
+	delay := f.cfg.minExtraDelay
+	if f.cfg.maxExtraDelay > f.cfg.minExtraDelay {
+		extra := f.cfg.maxExtraDelay - f.cfg.minExtraDelay
+		delay += time.Duration(f.rng.Int63n(int64(extra) + 1))
+	}
+
+	return delay, true
+}
+
+func (f *DuplicationFilter) scheduleDuplicate(dup Chunk, delay time.Duration) {
+	markChunkDuplicate(dup)
+
+	f.mu.Lock()
+	if f.closed {
+		f.mu.Unlock()
+
+		return
+	}
+
+	// bucketed scheduling, we group duplicates into fixed windows.
+	// this is to avoid creating a timer for each duplication.
+	now := f.now()
+	deadline := now.Add(delay)
+	bucketN := int64(duplicationBucketSize)
+	deadlineN := deadline.UnixNano()
+	// we round up to the next bucket boundary to avoid early delivery
+	fireAtN := ((deadlineN + bucketN - 1) / bucketN) * bucketN
+
+	bucket, ok := f.buckets[fireAtN]
+	if !ok {
+		fireAt := time.Unix(0, fireAtN)
+		wait := max(fireAt.Sub(now), 0)
+		bucket = &dupBucket{}
+		bucket.timer = time.AfterFunc(wait, func() {
+			f.onBucketFired(fireAtN)
+		})
+		f.buckets[fireAtN] = bucket
+		f.timers[bucket.timer] = struct{}{}
+	}
+
+	bucket.chunks = append(bucket.chunks, dup)
+	f.mu.Unlock()
+}
+
+func (f *DuplicationFilter) onBucketFired(key int64) {
+	f.mu.Lock()
+	if f.closed {
+		if bucket, ok := f.buckets[key]; ok {
+			delete(f.timers, bucket.timer)
+			delete(f.buckets, key)
+		}
+		f.mu.Unlock()
+
+		return
+	}
+
+	bucket, ok := f.buckets[key]
+	if ok {
+		delete(f.timers, bucket.timer)
+		delete(f.buckets, key)
+	}
+	chunks := bucket.chunks
+	f.mu.Unlock()
+
+	for i := 0; i < len(chunks); i++ {
+		f.router.push(chunks[i])
+	}
+}
+
+// Close cancels all pending duplicate deliveries and prevents future duplications.
+func (f *DuplicationFilter) Close() error {
+	f.mu.Lock()
+	if f.closed {
+		f.mu.Unlock()
+
+		return nil
+	}
+
+	f.closed = true
+	timers := make([]*time.Timer, 0, len(f.timers))
+	for timer := range f.timers {
+		timers = append(timers, timer)
+	}
+	f.mu.Unlock()
+
+	for _, timer := range timers {
+		timer.Stop()
+	}
+
+	return nil
+}
+
+func validateDuplicationConfig(cfg *duplicationConfig) error {
+	if cfg.prob < 0 || cfg.prob > 1 {
+		return errInvalidDuplicationProbability
+	}
+	if cfg.burstStartProb < 0 || cfg.burstStartProb > 1 {
+		return errInvalidDuplicationBurstProbability
+	}
+	if cfg.burstMultiplier < 1 {
+		return errInvalidDuplicationBurstMultiplier
+	}
+	if cfg.burstDuration < 0 {
+		return errInvalidDuplicationBurstDuration
+	}
+	if cfg.minExtraDelay < 0 || cfg.maxExtraDelay < 0 || cfg.maxExtraDelay < cfg.minExtraDelay {
+		return errInvalidDuplicationDelayRange
+	}
+
+	return nil
+}
+
+func chunkIsDuplicate(c Chunk) bool {
+	type duplicateChecker interface {
+		isDuplicate() bool
+	}
+
+	// a small cheat for test 100% test cov :)
+	if checker, ok := c.(duplicateChecker); ok && checker.isDuplicate() {
+		return true
+	}
+
+	return false
+}
+
+func markChunkDuplicate(c Chunk) {
+	type duplicateMarker interface {
+		markDuplicate()
+	}
+
+	if marker, ok := c.(duplicateMarker); ok {
+		marker.markDuplicate()
+	}
+}

--- a/vnet/duplication_filter_test.go
+++ b/vnet/duplication_filter_test.go
@@ -1,0 +1,854 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package vnet
+
+import (
+	"math/rand"
+	"net"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/pion/logging"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDuplicationFilterDuplicates(t *testing.T) {
+	loggerFactory := logging.NewDefaultLoggerFactory()
+
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: loggerFactory,
+	})
+	assert.NoError(t, err)
+
+	nic := make([]*dummyNIC, 2)
+	ip := make([]*net.UDPAddr, 2)
+
+	for i := 0; i < 2; i++ {
+		anet, netErr := NewNet(&NetConfig{})
+		assert.NoError(t, netErr)
+
+		nic[i] = &dummyNIC{Net: anet}
+		assert.NoError(t, router.AddNet(nic[i]))
+
+		eth0, errInterface := nic[i].getInterface("eth0")
+		assert.NoError(t, errInterface)
+
+		addrs, errAddrs := eth0.Addrs()
+		assert.NoError(t, errAddrs)
+		assert.Equal(t, 1, len(addrs))
+
+		ip[i] = &net.UDPAddr{ //nolint:forcetypeassert
+			IP:   addrs[0].(*net.IPNet).IP,
+			Port: 10000 + i,
+		}
+	}
+
+	dupFilter, err := NewDuplicationFilterWithOptions(
+		router,
+		WithDuplicationProbability(1.0),
+		WithDuplicationExtraDelay(20*time.Millisecond, 20*time.Millisecond),
+		WithDuplicationSeed(1),
+	)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, dupFilter.Close())
+	}()
+
+	router.AddChunkFilter(dupFilter.ChunkFilter())
+
+	received := make(chan Chunk, 4)
+	nic[1].onInboundChunkHandler = func(c Chunk) {
+		received <- c
+	}
+
+	assert.NoError(t, router.Start())
+	defer func() {
+		assert.NoError(t, router.Stop())
+	}()
+
+	chunk := newChunkUDP(ip[0], ip[1])
+	payload := []byte{0x42}
+	chunk.userData = make([]byte, len(payload))
+	copy(chunk.userData, payload)
+
+	start := time.Now()
+	router.push(chunk)
+
+	select {
+	case first := <-received:
+		assert.Equal(t, payload, first.UserData())
+	case <-time.After(200 * time.Millisecond):
+		assert.Fail(t, "expected primary chunk")
+	}
+
+	select {
+	case second := <-received:
+		elapsed := time.Since(start)
+		assert.GreaterOrEqual(t, elapsed, 18*time.Millisecond)
+		assert.Equal(t, payload, second.UserData())
+	case <-time.After(400 * time.Millisecond):
+		assert.Fail(t, "expected duplicate chunk")
+	}
+}
+
+func TestDuplicationFilterConfigValidation(t *testing.T) {
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: logging.NewDefaultLoggerFactory(),
+	})
+	assert.NoError(t, err)
+
+	_, err = NewDuplicationFilterWithOptions(router, WithDuplicationProbability(-0.1))
+	assert.ErrorIs(t, err, errInvalidDuplicationProbability)
+	_, err = NewDuplicationFilterWithOptions(router, WithDuplicationProbability(1.1))
+	assert.ErrorIs(t, err, errInvalidDuplicationProbability)
+
+	_, err = NewDuplicationFilterWithOptions(router, WithDuplicationBurstProbability(1.5))
+	assert.ErrorIs(t, err, errInvalidDuplicationBurstProbability)
+	_, err = NewDuplicationFilterWithOptions(router, WithDuplicationBurstProbability(-0.1))
+	assert.ErrorIs(t, err, errInvalidDuplicationBurstProbability)
+
+	_, err = NewDuplicationFilterWithOptions(router, WithDuplicationExtraDelay(time.Millisecond, -time.Millisecond))
+	assert.ErrorIs(t, err, errInvalidDuplicationDelayRange)
+
+	_, err = NewDuplicationFilterWithOptions(router, WithDuplicationExtraDelay(-time.Millisecond, time.Millisecond))
+	assert.ErrorIs(t, err, errInvalidDuplicationDelayRange)
+
+	_, err = NewDuplicationFilterWithOptions(router, WithDuplicationExtraDelay(time.Millisecond, time.Millisecond-1))
+	assert.ErrorIs(t, err, errInvalidDuplicationDelayRange)
+
+	_, err = NewDuplicationFilterWithOptions(router, WithDuplicationBurstDuration(-1))
+	assert.ErrorIs(t, err, errInvalidDuplicationBurstDuration)
+
+	_, err = NewDuplicationFilterWithOptions(router, WithDuplicationBurstMultiplier(0.5))
+	assert.ErrorIs(t, err, errInvalidDuplicationBurstMultiplier)
+
+	_, err = NewDuplicationFilterWithOptions(nil, WithDuplicationProbability(0.5))
+	assert.ErrorIs(t, err, errInvalidDuplicationRouter)
+}
+
+func TestValidateDuplicationConfig_Errors(t *testing.T) {
+	tests := []struct {
+		name     string
+		override duplicationConfig
+		err      error
+	}{
+		{
+			name:     "invalid prob < 0",
+			override: duplicationConfig{prob: -0.01},
+			err:      errInvalidDuplicationProbability,
+		},
+		{
+			name:     "invalid prob > 1",
+			override: duplicationConfig{prob: 1.01},
+			err:      errInvalidDuplicationProbability,
+		},
+		{
+			name:     "invalid burstStartProb < 0",
+			override: duplicationConfig{burstStartProb: -0.1},
+			err:      errInvalidDuplicationBurstProbability,
+		},
+		{
+			name:     "invalid burstStartProb > 1",
+			override: duplicationConfig{burstStartProb: 1.1},
+			err:      errInvalidDuplicationBurstProbability,
+		},
+		{
+			name:     "invalid burstMultiplier < 1",
+			override: duplicationConfig{burstMultiplier: 0.5},
+			err:      errInvalidDuplicationBurstMultiplier,
+		},
+		{
+			name:     "invalid burstDuration < 0",
+			override: duplicationConfig{burstDuration: -1},
+			err:      errInvalidDuplicationBurstDuration,
+		},
+		{
+			name:     "invalid delay min < 0",
+			override: duplicationConfig{minExtraDelay: -time.Nanosecond, maxExtraDelay: 0},
+			err:      errInvalidDuplicationDelayRange,
+		},
+		{
+			name:     "invalid delay max < 0",
+			override: duplicationConfig{minExtraDelay: 0, maxExtraDelay: -time.Nanosecond},
+			err:      errInvalidDuplicationDelayRange,
+		},
+		{
+			name:     "invalid delay max < min",
+			override: duplicationConfig{minExtraDelay: time.Millisecond, maxExtraDelay: time.Millisecond - 1},
+			err:      errInvalidDuplicationDelayRange,
+		},
+	}
+
+	for _, tc := range tests {
+		cfg := duplicationConfig{
+			prob:            0,
+			burstStartProb:  0,
+			burstDuration:   0,
+			burstMultiplier: 1,
+			minExtraDelay:   0,
+			maxExtraDelay:   0,
+		}
+
+		if tc.override.prob != 0 {
+			cfg.prob = tc.override.prob
+		}
+		if tc.override.burstStartProb != 0 {
+			cfg.burstStartProb = tc.override.burstStartProb
+		}
+		if tc.override.burstDuration != 0 {
+			cfg.burstDuration = tc.override.burstDuration
+		}
+		if tc.override.burstMultiplier != 0 {
+			cfg.burstMultiplier = tc.override.burstMultiplier
+		}
+		if tc.override.minExtraDelay != 0 || tc.override.maxExtraDelay != 0 {
+			cfg.minExtraDelay = tc.override.minExtraDelay
+			cfg.maxExtraDelay = tc.override.maxExtraDelay
+		}
+
+		err := validateDuplicationConfig(&cfg)
+		assert.ErrorIs(t, err, tc.err, tc.name)
+	}
+}
+
+func TestDuplicationImmediateOption(t *testing.T) {
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: logging.NewDefaultLoggerFactory(),
+	})
+	assert.NoError(t, err)
+
+	filter, err := NewDuplicationFilterWithOptions(
+		router,
+		WithDuplicationProbability(1.0),
+		WithDuplicationImmediate(),
+		WithDuplicationSeed(123),
+	)
+	assert.NoError(t, err)
+
+	delay, dup := filter.shouldDuplicate()
+	assert.True(t, dup)
+	assert.Equal(t, time.Duration(0), delay)
+}
+
+func TestDuplicationFilterClosedSkipsDuplication(t *testing.T) {
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: logging.NewDefaultLoggerFactory(),
+	})
+	assert.NoError(t, err)
+
+	filter, err := NewDuplicationFilterWithOptions(
+		router,
+		WithDuplicationProbability(1.0),
+		WithDuplicationExtraDelay(1*time.Millisecond, 1*time.Millisecond),
+		WithDuplicationSeed(9),
+	)
+	assert.NoError(t, err)
+
+	assert.NoError(t, filter.Close())
+
+	_, dup := filter.shouldDuplicate()
+	assert.False(t, dup)
+}
+
+func TestDuplicationDelayRangeInclusive(t *testing.T) {
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: logging.NewDefaultLoggerFactory(),
+	})
+	assert.NoError(t, err)
+
+	filter, err := NewDuplicationFilterWithOptions(
+		router,
+		WithDuplicationProbability(1.0),
+		WithDuplicationExtraDelay(0, 1*time.Nanosecond),
+		WithDuplicationSeed(42),
+	)
+	assert.NoError(t, err)
+
+	sawZero := false
+	sawMax := false
+	deadline := time.Now().Add(2 * time.Second)
+	for (!sawZero || !sawMax) && time.Now().Before(deadline) {
+		d, ok := filter.shouldDuplicate()
+		if !ok {
+			continue
+		}
+		if d == 0 {
+			sawZero = true
+		}
+		if d == 1*time.Nanosecond {
+			sawMax = true
+		}
+	}
+
+	assert.True(t, sawZero, "expected to observe minimum delay")
+	assert.True(t, sawMax, "expected to observe maximum delay inclusively")
+}
+
+func TestDuplicationFilterZeroDelayNoLoop(t *testing.T) {
+	loggerFactory := logging.NewDefaultLoggerFactory()
+
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: loggerFactory,
+	})
+	assert.NoError(t, err)
+
+	nic := make([]*dummyNIC, 2)
+	ip := make([]*net.UDPAddr, 2)
+
+	for i := 0; i < 2; i++ {
+		anet, netErr := NewNet(&NetConfig{})
+		assert.NoError(t, netErr)
+
+		nic[i] = &dummyNIC{Net: anet}
+		assert.NoError(t, router.AddNet(nic[i]))
+
+		eth0, errInterface := nic[i].getInterface("eth0")
+		assert.NoError(t, errInterface)
+
+		addrs, errAddrs := eth0.Addrs()
+		assert.NoError(t, errAddrs)
+		assert.Equal(t, 1, len(addrs))
+
+		ip[i] = &net.UDPAddr{ //nolint:forcetypeassert
+			IP:   addrs[0].(*net.IPNet).IP,
+			Port: 11000 + i,
+		}
+	}
+
+	dupFilter, err := NewDuplicationFilterWithOptions(
+		router,
+		WithDuplicationProbability(1.0),
+		WithDuplicationExtraDelay(0, 0),
+		WithDuplicationSeed(7),
+	)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, dupFilter.Close())
+	}()
+
+	router.AddChunkFilter(dupFilter.ChunkFilter())
+
+	received := make(chan Chunk, 8)
+	nic[1].onInboundChunkHandler = func(c Chunk) {
+		received <- c
+	}
+
+	assert.NoError(t, router.Start())
+	defer func() {
+		assert.NoError(t, router.Stop())
+	}()
+
+	chunk := newChunkUDP(ip[0], ip[1])
+	payload := []byte{0x99}
+	chunk.userData = make([]byte, len(payload))
+	copy(chunk.userData, payload)
+
+	router.push(chunk)
+
+	select {
+	case first := <-received:
+		assert.Equal(t, payload, first.UserData())
+	case <-time.After(200 * time.Millisecond):
+		assert.Fail(t, "expected primary chunk")
+	}
+
+	select {
+	case second := <-received:
+		assert.Equal(t, payload, second.UserData())
+	case <-time.After(200 * time.Millisecond):
+		assert.Fail(t, "expected duplicate chunk")
+	}
+
+	select {
+	case extra := <-received:
+		assert.Failf(t, "duplicate loop detected", "unexpected chunk: %s", extra.String())
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestDuplicationFilterBurstMultiplier(t *testing.T) {
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: logging.NewDefaultLoggerFactory(),
+	})
+	assert.NoError(t, err)
+
+	baseOpts := []DuplicationOption{
+		WithDuplicationProbability(0.2),
+		WithDuplicationBurstProbability(1.0),
+		WithDuplicationBurstDuration(50 * time.Millisecond),
+		WithDuplicationExtraDelay(0, 0),
+	}
+
+	baseline, err := NewDuplicationFilterWithOptions(router, append(baseOpts, WithDuplicationBurstMultiplier(1))...)
+	assert.NoError(t, err)
+	boosted, err := NewDuplicationFilterWithOptions(router, append(baseOpts, WithDuplicationBurstMultiplier(5))...)
+	assert.NoError(t, err)
+
+	now := time.Now()
+	baseline.now = func() time.Time { return now }
+	boosted.now = baseline.now
+	baseline.burstEnd = now.Add(25 * time.Millisecond)
+	boosted.burstEnd = baseline.burstEnd
+
+	baseline.rng = rand.New(rand.NewSource(1)) //nolint:gosec // weak rand is intended
+	boosted.rng = rand.New(rand.NewSource(1))  //nolint:gosec // weak rand is intended
+
+	_, baselineDup := baseline.shouldDuplicate()
+	_, boostedDup := boosted.shouldDuplicate()
+
+	assert.False(t, baselineDup, "baseline probability should fail for value above 0.2")
+	assert.True(t, boostedDup, "burst multiplier should allow duplication")
+}
+
+func TestDuplicationFilterCloseCancelsPending(t *testing.T) {
+	loggerFactory := logging.NewDefaultLoggerFactory()
+
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: loggerFactory,
+	})
+	assert.NoError(t, err)
+
+	nic := make([]*dummyNIC, 2)
+	ip := make([]*net.UDPAddr, 2)
+
+	for i := 0; i < 2; i++ {
+		anet, netErr := NewNet(&NetConfig{})
+		assert.NoError(t, netErr)
+
+		nic[i] = &dummyNIC{Net: anet}
+		assert.NoError(t, router.AddNet(nic[i]))
+
+		eth0, errInterface := nic[i].getInterface("eth0")
+		assert.NoError(t, errInterface)
+
+		addrs, errAddrs := eth0.Addrs()
+		assert.NoError(t, errAddrs)
+		assert.Equal(t, 1, len(addrs))
+
+		ip[i] = &net.UDPAddr{ //nolint:forcetypeassert
+			IP:   addrs[0].(*net.IPNet).IP,
+			Port: 12000 + i,
+		}
+	}
+
+	dupFilter, err := NewDuplicationFilterWithOptions(
+		router,
+		WithDuplicationProbability(1.0),
+		WithDuplicationExtraDelay(100*time.Millisecond, 100*time.Millisecond),
+		WithDuplicationSeed(3),
+	)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, dupFilter.Close())
+	}()
+
+	router.AddChunkFilter(dupFilter.ChunkFilter())
+
+	received := make(chan Chunk, 4)
+	nic[1].onInboundChunkHandler = func(c Chunk) {
+		received <- c
+	}
+
+	assert.NoError(t, router.Start())
+	defer func() {
+		assert.NoError(t, router.Stop())
+	}()
+
+	chunk := newChunkUDP(ip[0], ip[1])
+	chunk.userData = []byte{0x01}
+	router.push(chunk)
+
+	select {
+	case <-received:
+		// primary chunk delivered
+	case <-time.After(200 * time.Millisecond):
+		assert.Fail(t, "expected primary chunk before close")
+	}
+
+	assert.NoError(t, dupFilter.Close())
+
+	select {
+	case extra := <-received:
+		assert.Failf(t, "duplicate delivered after close", "unexpected chunk: %s", extra.String())
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+func TestDuplicationFilterProbabilityLongRun(t *testing.T) {
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: logging.NewDefaultLoggerFactory(),
+	})
+	assert.NoError(t, err)
+
+	filter, err := NewDuplicationFilterWithOptions(
+		router,
+		WithDuplicationProbability(0.3),
+		WithDuplicationExtraDelay(0, 0),
+		WithDuplicationSeed(2023),
+	)
+	assert.NoError(t, err)
+
+	const iterations = 50000
+	dupCount := 0
+	for i := 0; i < iterations; i++ {
+		_, dup := filter.shouldDuplicate()
+		if dup {
+			dupCount++
+		}
+	}
+
+	ratio := float64(dupCount) / float64(iterations)
+	assert.InDelta(t, 0.3, ratio, 0.02)
+}
+
+func TestDuplicationFilterBucketCoalescing(t *testing.T) { //nolint:cyclop
+	loggerFactory := logging.NewDefaultLoggerFactory()
+
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: loggerFactory,
+	})
+	assert.NoError(t, err)
+
+	nic := make([]*dummyNIC, 2)
+	ip := make([]*net.UDPAddr, 2)
+
+	for i := 0; i < 2; i++ {
+		anet, netErr := NewNet(&NetConfig{})
+		assert.NoError(t, netErr)
+
+		nic[i] = &dummyNIC{Net: anet}
+		assert.NoError(t, router.AddNet(nic[i]))
+
+		eth0, errInterface := nic[i].getInterface("eth0")
+		assert.NoError(t, errInterface)
+
+		addrs, errAddrs := eth0.Addrs()
+		assert.NoError(t, errAddrs)
+		assert.Equal(t, 1, len(addrs))
+
+		ip[i] = &net.UDPAddr{ //nolint:forcetypeassert
+			IP:   addrs[0].(*net.IPNet).IP,
+			Port: 13000 + i,
+		}
+	}
+
+	dupFilter, err := NewDuplicationFilterWithOptions(
+		router,
+		WithDuplicationProbability(1.0),
+		WithDuplicationExtraDelay(500*time.Microsecond, 500*time.Microsecond),
+		WithDuplicationSeed(11),
+	)
+	assert.NoError(t, err)
+	defer func() {
+		assert.NoError(t, dupFilter.Close())
+	}()
+
+	router.AddChunkFilter(dupFilter.ChunkFilter())
+
+	type arrival struct{ t time.Time }
+	const size = 40
+	arrivals := make([][]arrival, size)
+
+	received := make(chan Chunk, 2*size)
+	nic[1].onInboundChunkHandler = func(c Chunk) {
+		received <- c
+	}
+
+	assert.NoError(t, router.Start())
+	defer func() {
+		assert.NoError(t, router.Stop())
+	}()
+
+	for i := 0; i < size; i++ {
+		chunk := newChunkUDP(ip[0], ip[1])
+		payload := []byte{byte(i)}
+		chunk.userData = make([]byte, len(payload))
+		copy(chunk.userData, payload)
+		router.push(chunk)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for done := 0; done < 2*size; {
+		select {
+		case c := <-received:
+			if data := c.UserData(); len(data) == 1 {
+				idx := int(data[0])
+				arrivals[idx] = append(arrivals[idx], arrival{t: time.Now()})
+				done++
+			}
+		case <-deadline:
+			assert.Fail(t, "timeout waiting for %d arrivals, got %d", 2*size, done)
+		}
+	}
+
+	var firstDup, lastDup time.Time
+	for i := 0; i < size; i++ {
+		pair := arrivals[i]
+		assert.Len(t, pair, 2, "expected primary and duplicate for index %d", i)
+		primary, duplicate := pair[0].t, pair[1].t
+
+		dupDelay := duplicate.Sub(primary)
+		minDelay := 100 * time.Microsecond
+		if runtime.GOOS == "windows" {
+			// Windows timers can have low resolution.
+			minDelay = 0
+		}
+		assert.GreaterOrEqual(t, dupDelay, minDelay)
+		assert.LessOrEqual(t, dupDelay, 5*time.Millisecond)
+
+		if firstDup.IsZero() || duplicate.Before(firstDup) {
+			firstDup = duplicate
+		}
+		if lastDup.IsZero() || duplicate.After(lastDup) {
+			lastDup = duplicate
+		}
+	}
+
+	coalesceSpan := lastDup.Sub(firstDup)
+	assert.LessOrEqual(t, coalesceSpan, 6*time.Millisecond)
+}
+
+func TestDuplicationFilterBurstStartSetsWindow(t *testing.T) {
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: logging.NewDefaultLoggerFactory(),
+	})
+	assert.NoError(t, err)
+
+	filter, err := NewDuplicationFilterWithOptions(
+		router,
+		WithDuplicationProbability(0.0),
+		WithDuplicationBurstProbability(1.0),
+		WithDuplicationBurstDuration(10*time.Millisecond),
+		WithDuplicationExtraDelay(0, 0),
+		WithDuplicationSeed(1234),
+	)
+	assert.NoError(t, err)
+
+	fixedNow := time.Now()
+	filter.now = func() time.Time { return fixedNow }
+
+	assert.True(t, filter.burstEnd.IsZero())
+
+	_, _ = filter.shouldDuplicate()
+
+	expectedEnd := fixedNow.Add(10 * time.Millisecond)
+	assert.WithinDuration(t, expectedEnd, filter.burstEnd, time.Microsecond)
+}
+
+func TestDuplicationFilterOnBucketFiredClosedCleans(t *testing.T) {
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: logging.NewDefaultLoggerFactory(),
+	})
+	assert.NoError(t, err)
+
+	filter, err := NewDuplicationFilterWithOptions(
+		router,
+		WithDuplicationProbability(0.0),
+		WithDuplicationExtraDelay(0, 0),
+		WithDuplicationSeed(1),
+	)
+	assert.NoError(t, err)
+
+	key := time.Now().Add(1 * time.Minute).UnixNano()
+	tm := time.NewTimer(10 * time.Minute)
+	defer tm.Stop()
+
+	filter.mu.Lock()
+	b := &dupBucket{timer: tm}
+	filter.buckets[key] = b
+	filter.timers[tm] = struct{}{}
+	filter.closed = true
+	filter.mu.Unlock()
+
+	filter.onBucketFired(key)
+
+	filter.mu.Lock()
+	_, bucketExists := filter.buckets[key]
+	_, timerExists := filter.timers[tm]
+	filter.mu.Unlock()
+
+	assert.False(t, bucketExists, "bucket should be removed when closed")
+	assert.False(t, timerExists, "timer should be removed when closed")
+}
+
+func TestDuplicationFilterScheduleDuplicateClosedNoop(t *testing.T) {
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: logging.NewDefaultLoggerFactory(),
+	})
+	assert.NoError(t, err)
+
+	filter, err := NewDuplicationFilterWithOptions(
+		router,
+		WithDuplicationProbability(1.0),
+		WithDuplicationExtraDelay(1*time.Millisecond, 1*time.Millisecond),
+		WithDuplicationSeed(5),
+	)
+	assert.NoError(t, err)
+
+	filter.mu.Lock()
+	filter.closed = true
+	initialTimers := len(filter.timers)
+	initialBuckets := len(filter.buckets)
+	filter.mu.Unlock()
+
+	dup := newChunkUDP(&net.UDPAddr{}, &net.UDPAddr{})
+	filter.scheduleDuplicate(dup, 1*time.Millisecond)
+
+	time.Sleep(10 * time.Millisecond)
+
+	filter.mu.Lock()
+	defer filter.mu.Unlock()
+	assert.Equal(t, initialTimers, len(filter.timers))
+	assert.Equal(t, initialBuckets, len(filter.buckets))
+}
+
+func TestNewDuplicationFilter_NilOptionIgnored(t *testing.T) {
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: logging.NewDefaultLoggerFactory(),
+	})
+	assert.NoError(t, err)
+
+	filter, err := NewDuplicationFilterWithOptions(
+		router,
+		WithDuplicationProbability(1.0),
+		// should be ignored.
+		nil,
+		WithDuplicationImmediate(),
+		WithDuplicationSeed(12345),
+	)
+	assert.NoError(t, err)
+
+	defer func() { _ = filter.Close() }()
+
+	delay, dup := filter.shouldDuplicate()
+	assert.True(t, dup)
+	assert.Equal(t, time.Duration(0), delay)
+}
+
+func TestNewDuplicationFilter_ValidateCalledOnOptions(t *testing.T) {
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: logging.NewDefaultLoggerFactory(),
+	})
+	assert.NoError(t, err)
+
+	invalidNoReturn := func(cfg *duplicationConfig) error {
+		cfg.burstMultiplier = 0
+
+		return nil
+	}
+
+	_, err = NewDuplicationFilterWithOptions(
+		router,
+		WithDuplicationProbability(0.5),
+		DuplicationOption(invalidNoReturn),
+	)
+	assert.ErrorIs(t, err, errInvalidDuplicationBurstMultiplier)
+}
+
+func TestDuplicationFilterBurstImmediateAppliesMultiplier(t *testing.T) {
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: logging.NewDefaultLoggerFactory(),
+	})
+	assert.NoError(t, err)
+
+	// choose a seed and precompute the first two Float64 draws.
+	// the first draw will be consumed by the burst-start check,
+	// the second draw will be used for the duplication probability check.
+	const seed int64 = 99
+	probe := rand.New(rand.NewSource(seed)) //nolint:gosec // weak rand is intended
+	_ = probe.Float64()                     // consumed by burst-start path
+	secondDraw := probe.Float64()           // will be used for duplication probability
+
+	// pick base probability just below the second draw so that without multiplier
+	// the duplication would NOT occur (rng >= baseProb).
+	const eps = 1e-9
+	baseProb := secondDraw - eps
+	if baseProb < 0 {
+		baseProb = 0
+	}
+
+	// multiplier 2x ensures boosted probability > secondDraw (or clamps to 1),
+	// so duplication should occur on the same call where the burst starts.
+	const mult = 2.0
+
+	filter, err := NewDuplicationFilterWithOptions(
+		router,
+		WithDuplicationProbability(baseProb),
+		WithDuplicationBurstProbability(1.0),
+		WithDuplicationBurstDuration(10*time.Millisecond),
+		WithDuplicationBurstMultiplier(mult),
+		WithDuplicationExtraDelay(0, 0),
+		WithDuplicationSeed(seed),
+	)
+	assert.NoError(t, err)
+
+	fixedNow := time.Now()
+	filter.now = func() time.Time { return fixedNow }
+	// Ensure we are outside any burst window before the call
+	filter.burstEnd = time.Time{}
+
+	// On this single call:
+	// 1) burst will start (burstStartProb=1)
+	// 2) multiplier must apply immediately to this packet
+	// 3) duplication should succeed deterministically
+	_, dup := filter.shouldDuplicate()
+	assert.True(t, dup, "expected immediate application of burst multiplier to current packet")
+}
+
+func TestDuplicationFilterBurstBoundaryEqualityNotInBurst(t *testing.T) {
+	router, err := NewRouter(&RouterConfig{
+		CIDR:          "1.2.3.0/24",
+		LoggerFactory: logging.NewDefaultLoggerFactory(),
+	})
+	assert.NoError(t, err)
+
+	// use a known seed and compute the first Float64 draw which will be used
+	// for the duplication probability check (no burst-start draw will happen
+	// since we are exactly at the boundary. neither After nor Before).
+	const seed int64 = 123
+	probe := rand.New(rand.NewSource(seed)) //nolint:gosec // weak rand is intended
+	firstDraw := probe.Float64()
+
+	const eps = 1e-9
+	baseProb := firstDraw - eps
+	if baseProb < 0 {
+		baseProb = 0
+	}
+
+	filter, err := NewDuplicationFilterWithOptions(
+		router,
+		WithDuplicationProbability(baseProb),
+		WithDuplicationBurstProbability(1.0),
+		WithDuplicationBurstDuration(10*time.Millisecond),
+		WithDuplicationBurstMultiplier(10.0),
+		WithDuplicationExtraDelay(0, 0),
+		WithDuplicationSeed(seed),
+	)
+	assert.NoError(t, err)
+
+	fixedNow := time.Now()
+	filter.now = func() time.Time { return fixedNow }
+	// set burstEnd exactly to now: equality should be treated as out-of-burst
+	filter.burstEnd = fixedNow
+
+	_, dup := filter.shouldDuplicate()
+	assert.False(t, dup, "equality boundary must not apply burst multiplier")
+}


### PR DESCRIPTION
#### Description
add a filter to duplicate packets.
to test network conditions where packets are duplicated intentionally or by a malformed network device etc

Lore: When I was a kid, I had this POS ISP-issued router that duplicated packets at insane rates. It took me a while to figure out what was going on, but it broke all sorts of network applications and poorly coded games network code. once I finally discovered the cause, it felt like having a superpower xd, being able to uncover a bug that was almost impossible to reproduce under normal conditions.

