### PR TITLE
Make loss-filter deterministic

### DIFF
--- a/vnet/duplication_filter.go
+++ b/vnet/duplication_filter.go
@@ -180,15 +180,7 @@ func NewDuplicationFilterWithOptions(router *Router, opts ...DuplicationOption) 
 		return nil, err
 	}
 
-	var rng *rand.Rand
-
-	if cfg.seed == nil {
-		// nolint:gosec // weak rand is intended
-		rng = rand.New(rand.NewSource(time.Now().UnixNano()))
-	} else {
-		// nolint:gosec // weak rand is intended
-		rng = rand.New(rand.NewSource(*cfg.seed))
-	}
+	rng := newRNG(cfg.seed)
 
 	return &DuplicationFilter{
 		router:  router,


### PR DESCRIPTION
#### Description

Add `WithLossSeed` to enable deterministic loss behavior, fix a small RNG race, and add a ton of new tests to test the behavior.
