### PR TITLE
Use ping-pong buffer for batch conn

### DIFF
--- a/udp/batchconn.go
+++ b/udp/batchconn.go
@@ -32,6 +32,233 @@ type BatchPacketConn interface {
 	io.Closer
 }
 
+// ---------------------------------
+
+type messageBatch struct {
+	size      int
+	batchConn BatchPacketConn
+
+	mu       sync.Mutex
+	messages []ipv4.Message
+	writePos int
+}
+
+func newMessageBatch(size int, batchConn BatchPacketConn) *messageBatch {
+	m := &messageBatch{
+		size:      size,
+		batchConn: batchConn,
+	}
+	m.init()
+
+	return m
+}
+
+func (m *messageBatch) init() {
+	m.messages = make([]ipv4.Message, m.size)
+	for i := range m.messages {
+		m.messages[i].Buffers = [][]byte{make([]byte, sendMTU)}
+	}
+}
+
+func (m *messageBatch) isFull() bool {
+	return m.writePos == m.size
+}
+
+func (m *messageBatch) EnqueueMessage(buf []byte, raddr net.Addr) (int, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if len(buf) == 0 || m.isFull() {
+		return 0, m.isFull()
+	}
+
+	msg := &m.messages[m.writePos]
+	// reset buffers
+	msg.Buffers = msg.Buffers[:1]
+	msg.Buffers[0] = msg.Buffers[0][:cap(msg.Buffers[0])]
+
+	if raddr != nil {
+		msg.Addr = raddr
+	}
+	if n := copy(msg.Buffers[0], buf); n < len(buf) {
+		extraBuffer := make([]byte, len(buf)-n)
+		copy(extraBuffer, buf[n:])
+		msg.Buffers = append(msg.Buffers, extraBuffer)
+	} else {
+		msg.Buffers[0] = msg.Buffers[0][:n]
+	}
+	m.writePos++
+
+	return len(buf), m.isFull()
+}
+
+func (m *messageBatch) Flush() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var txN int
+	for txN < m.writePos {
+		n, err := m.batchConn.WriteBatch(m.messages[txN:m.writePos], 0)
+		if err != nil {
+			break
+		}
+		txN += n
+	}
+
+	m.writePos = 0
+}
+
+// ---------------------------------
+
+type pingPong struct {
+	mu            sync.Mutex
+	batches       [2]*messageBatch
+	writeBatchIdx int
+	readBatchIdx  int
+	flushPending  bool
+
+	writeReady     chan struct{}
+	flushCycleDone chan struct{}
+	flusherDone    chan struct{}
+
+	closed int32
+}
+
+func newPingPong(size int, interval time.Duration, batchConn BatchPacketConn) *pingPong {
+	p := &pingPong{
+		writeReady:     make(chan struct{}),
+		flushCycleDone: make(chan struct{}),
+		flusherDone:    make(chan struct{}),
+	}
+	for i := 0; i < len(p.batches); i++ {
+		p.batches[i] = newMessageBatch(size, batchConn)
+	}
+
+	go p.flusher(interval)
+
+	return p
+}
+
+func (p *pingPong) Close() {
+	atomic.StoreInt32(&p.closed, 1)
+
+	select {
+	case p.writeReady <- struct{}{}:
+	default:
+	}
+
+	<-p.flusherDone
+}
+
+func (p *pingPong) EnqueueMessage(buf []byte, raddr net.Addr) int {
+	p.mu.Lock()
+	var (
+		writeBatch *messageBatch
+		n          int
+		isFull     bool
+	)
+	for {
+		if writeBatch = p.getWriteBatch(); writeBatch != nil {
+			n, isFull = writeBatch.EnqueueMessage(buf, raddr)
+			if n == len(buf) {
+				break
+			}
+		}
+
+		p.mu.Unlock()
+		select {
+		case <-p.flushCycleDone:
+		case <-time.After(100 * time.Microsecond):
+		}
+
+		if atomic.LoadInt32(&p.closed) == 1 {
+			return 0
+		}
+
+		p.mu.Lock()
+	}
+	p.mu.Unlock()
+
+	// enqueuing given message fills up the write batch, queue up a flush
+	if isFull {
+		select {
+		case p.writeReady <- struct{}{}:
+		default:
+		}
+	}
+
+	return n
+}
+
+func (p *pingPong) getWriteBatch() *messageBatch {
+	if p.writeBatchIdx == p.readBatchIdx && p.flushPending {
+		return nil
+	}
+
+	return p.batches[p.writeBatchIdx]
+}
+
+func (p *pingPong) updateWriteBatchAndGetReadBatch() *messageBatch {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.writeBatchIdx != p.readBatchIdx || p.flushPending {
+		return nil
+	}
+
+	p.writeBatchIdx ^= 1
+	p.flushPending = true
+
+	return p.batches[p.readBatchIdx]
+}
+
+func (p *pingPong) updateReadBatch() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.flushPending {
+		return
+	}
+
+	p.readBatchIdx ^= 1
+	p.flushPending = false
+
+	select {
+	case p.flushCycleDone <- struct{}{}:
+	default:
+	}
+}
+
+func (p *pingPong) flusher(interval time.Duration) {
+	defer close(p.flusherDone)
+
+	writeTicker := time.NewTicker(interval / 2)
+	defer writeTicker.Stop()
+
+	lastFlushAt := time.Now().Add(-interval)
+	for atomic.LoadInt32(&p.closed) != 1 {
+		select {
+		case <-writeTicker.C:
+			if time.Since(lastFlushAt) < interval {
+				continue
+			}
+		case <-p.writeReady:
+		}
+
+		readBatch := p.updateWriteBatchAndGetReadBatch()
+		if readBatch == nil {
+			continue
+		}
+
+		readBatch.Flush()
+		p.updateReadBatch()
+
+		lastFlushAt = time.Now()
+	}
+}
+
+// ------------------------------
+
 // BatchConn uses ipv4/v6.NewPacketConn to wrap a net.PacketConn to write/read messages in batch,
 // only available in linux. In other platform, it will use single Write/Read as same as net.Conn.
 type BatchConn struct {
@@ -39,28 +266,14 @@ type BatchConn struct {
 
 	batchConn BatchPacketConn
 
-	batchWriteMutex    sync.Mutex
-	batchWriteMessages []ipv4.Message
-	batchWritePos      int
-	batchWriteLast     time.Time
-
-	batchWriteSize     int
-	batchWriteInterval time.Duration
-
-	closed int32
+	// ping-pong the batches to be able to accept new packets while a batch is written to socket
+	batchPingPong *pingPong
 }
 
 // NewBatchConn creates a *BatchConn from net.PacketConn with batch configs.
 func NewBatchConn(conn net.PacketConn, batchWriteSize int, batchWriteInterval time.Duration) *BatchConn {
 	bc := &BatchConn{
-		PacketConn:         conn,
-		batchWriteLast:     time.Now(),
-		batchWriteInterval: batchWriteInterval,
-		batchWriteSize:     batchWriteSize,
-		batchWriteMessages: make([]ipv4.Message, batchWriteSize),
-	}
-	for i := range bc.batchWriteMessages {
-		bc.batchWriteMessages[i].Buffers = [][]byte{make([]byte, sendMTU)}
+		PacketConn: conn,
 	}
 
 	// batch write only supports linux
@@ -70,21 +283,8 @@ func NewBatchConn(conn net.PacketConn, batchWriteSize int, batchWriteInterval ti
 		} else if pc6 := ipv6.NewPacketConn(conn); pc6 != nil {
 			bc.batchConn = pc6
 		}
-	}
 
-	if bc.batchConn != nil {
-		go func() {
-			writeTicker := time.NewTicker(batchWriteInterval / 2)
-			defer writeTicker.Stop()
-			for atomic.LoadInt32(&bc.closed) != 1 {
-				<-writeTicker.C
-				bc.batchWriteMutex.Lock()
-				if bc.batchWritePos > 0 && time.Since(bc.batchWriteLast) >= bc.batchWriteInterval {
-					_ = bc.flush()
-				}
-				bc.batchWriteMutex.Unlock()
-			}
-		}()
+		bc.batchPingPong = newPingPong(batchWriteSize, batchWriteInterval, bc.batchConn)
 	}
 
 	return bc
@@ -92,12 +292,10 @@ func NewBatchConn(conn net.PacketConn, batchWriteSize int, batchWriteInterval ti
 
 // Close batchConn and the underlying PacketConn.
 func (c *BatchConn) Close() error {
-	atomic.StoreInt32(&c.closed, 1)
-	c.batchWriteMutex.Lock()
-	if c.batchWritePos > 0 {
-		_ = c.flush()
+	if c.batchPingPong != nil {
+		c.batchPingPong.Close()
 	}
-	c.batchWriteMutex.Unlock()
+
 	if c.batchConn != nil {
 		return c.batchConn.Close()
 	}
@@ -111,35 +309,7 @@ func (c *BatchConn) WriteTo(b []byte, addr net.Addr) (int, error) {
 		return c.PacketConn.WriteTo(b, addr)
 	}
 
-	return c.enqueueMessage(b, addr)
-}
-
-func (c *BatchConn) enqueueMessage(buf []byte, raddr net.Addr) (int, error) {
-	var err error
-	c.batchWriteMutex.Lock()
-	defer c.batchWriteMutex.Unlock()
-
-	msg := &c.batchWriteMessages[c.batchWritePos]
-	// reset buffers
-	msg.Buffers = msg.Buffers[:1]
-	msg.Buffers[0] = msg.Buffers[0][:cap(msg.Buffers[0])]
-
-	c.batchWritePos++
-	if raddr != nil {
-		msg.Addr = raddr
-	}
-	if n := copy(msg.Buffers[0], buf); n < len(buf) {
-		extraBuffer := make([]byte, len(buf)-n)
-		copy(extraBuffer, buf[n:])
-		msg.Buffers = append(msg.Buffers, extraBuffer)
-	} else {
-		msg.Buffers[0] = msg.Buffers[0][:n]
-	}
-	if c.batchWritePos == c.batchWriteSize {
-		err = c.flush()
-	}
-
-	return len(buf), err
+	return c.batchPingPong.EnqueueMessage(b, addr), nil
 }
 
 // ReadBatch reads messages in batch, return length of message readed and error.
@@ -157,22 +327,4 @@ func (c *BatchConn) ReadBatch(msgs []ipv4.Message, flags int) (int, error) {
 	}
 
 	return c.batchConn.ReadBatch(msgs, flags)
-}
-
-func (c *BatchConn) flush() error {
-	var writeErr error
-	var txN int
-	for txN < c.batchWritePos {
-		n, err := c.batchConn.WriteBatch(c.batchWriteMessages[txN:c.batchWritePos], 0)
-		if err != nil {
-			writeErr = err
-
-			break
-		}
-		txN += n
-	}
-	c.batchWritePos = 0
-	c.batchWriteLast = time.Now()
-
-	return writeErr
 }

--- a/udp/batchconn_test.go
+++ b/udp/batchconn_test.go
@@ -1,0 +1,271 @@
+// SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+//go:build linux
+
+package udp
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pion/transport/v3/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBatchConn_WriteBatchInterval(t *testing.T) {
+	report := test.CheckRoutines(t)
+	defer report()
+
+	lc := ListenConfig{
+		Batch: BatchIOConfig{
+			Enable:             true,
+			ReadBatchSize:      10,
+			WriteBatchSize:     3,
+			WriteBatchInterval: 5 * time.Millisecond,
+		},
+		ReadBufferSize:  64 * 1024,
+		WriteBufferSize: 64 * 1024,
+	}
+
+	laddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 15678}
+	listener, err := lc.Listen("udp", laddr)
+	assert.NoError(t, err)
+
+	var serverConnWg sync.WaitGroup
+	serverConnWg.Add(1)
+	go func() { //nolint:dupl
+		var exit int32
+		defer func() {
+			defer serverConnWg.Done()
+			atomic.StoreInt32(&exit, 1)
+		}()
+		for {
+			buf := make([]byte, 1400)
+			conn, lerr := listener.Accept()
+			if errors.Is(lerr, ErrClosedListener) {
+				break
+			}
+			assert.NoError(t, lerr)
+			serverConnWg.Add(1)
+			go func() {
+				defer func() {
+					_ = conn.Close()
+					serverConnWg.Done()
+				}()
+				for atomic.LoadInt32(&exit) != 1 {
+					_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+					n, rerr := conn.Read(buf)
+					if rerr != nil {
+						assert.ErrorContains(t, rerr, "timeout")
+					} else {
+						_, rerr = conn.Write(buf[:n])
+						assert.NoError(t, rerr)
+					}
+				}
+			}()
+		}
+	}()
+
+	raddr, _ := listener.Addr().(*net.UDPAddr)
+
+	// test flush by WriteBatchInterval expired
+	readBuf := make([]byte, 1400)
+	cli, err := net.DialUDP("udp", nil, raddr)
+	assert.NoError(t, err)
+	flushStr := "flushbytimer"
+	_, err = cli.Write([]byte("flushbytimer"))
+	assert.NoError(t, err)
+	n, err := cli.Read(readBuf)
+	assert.NoError(t, err)
+	assert.Equal(t, flushStr, string(readBuf[:n]))
+
+	_ = listener.Close()
+	serverConnWg.Wait()
+}
+
+func TestBatchConn_WriteBatchSize(t *testing.T) { //nolint:cyclop
+	report := test.CheckRoutines(t)
+	defer report()
+
+	lc := ListenConfig{
+		Batch: BatchIOConfig{
+			Enable:             true,
+			ReadBatchSize:      10,
+			WriteBatchSize:     9,
+			WriteBatchInterval: time.Minute,
+		},
+		ReadBufferSize:  64 * 1024,
+		WriteBufferSize: 64 * 1024,
+	}
+
+	laddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 15678}
+	listener, err := lc.Listen("udp", laddr)
+	assert.NoError(t, err)
+
+	var serverConnWg sync.WaitGroup
+	serverConnWg.Add(1)
+	go func() { //nolint:dupl
+		var exit int32
+		defer func() {
+			defer serverConnWg.Done()
+			atomic.StoreInt32(&exit, 1)
+		}()
+		for {
+			buf := make([]byte, 1400)
+			conn, lerr := listener.Accept()
+			if errors.Is(lerr, ErrClosedListener) {
+				break
+			}
+			assert.NoError(t, lerr)
+			serverConnWg.Add(1)
+			go func() {
+				defer func() {
+					_ = conn.Close()
+					serverConnWg.Done()
+				}()
+				for atomic.LoadInt32(&exit) != 1 {
+					_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+					n, rerr := conn.Read(buf)
+					if rerr != nil {
+						assert.ErrorContains(t, rerr, "timeout")
+					} else {
+						_, rerr = conn.Write(buf[:n])
+						assert.NoError(t, rerr)
+					}
+				}
+			}()
+		}
+	}()
+
+	raddr, _ := listener.Addr().(*net.UDPAddr)
+
+	// three clients writing three packets each,
+	// server is batching 9 packets at a time, echoing back packets from client,
+	// do two batches of writes from each client, two packets first cycle and one packet in second cycle
+	//    - should not be able to read any packets after first write as the server is batching packets
+	//    - should be able to read three packets from each client as server would have flushed nine packets
+	// to ensure that write batch interval does not kick in, setting the write batch interval to a large value (1m)
+	cc := 3
+	var clients [3]*net.UDPConn
+	wgs := sync.WaitGroup{}
+
+	// first cycle, write two packets from each client,
+	// should not be able to read any packets
+	wgs.Add(cc)
+	for i := 0; i < cc; i++ {
+		sendStr := fmt.Sprintf("hello %d", i)
+
+		idx := i
+		go func() {
+			defer wgs.Done()
+
+			client, err := net.DialUDP("udp", nil, raddr)
+			assert.NoError(t, err)
+			clients[idx] = client
+
+			for j := 0; j < 2; j++ {
+				_, err = client.Write([]byte(sendStr))
+				assert.NoError(t, err)
+			}
+
+			err = client.SetReadDeadline(time.Now().Add(time.Second))
+			assert.NoError(t, err)
+
+			buf := make([]byte, 1400)
+			n, err := client.Read(buf)
+			assert.Zero(t, n, "unexpected packet from client: %d", idx)
+			assert.ErrorContains(t, err, "timeout", "expected timeout from client: %d", idx)
+		}()
+	}
+	wgs.Wait()
+
+	// second cycle, write two packets from each client,
+	// should be able to read three packets on average per client
+	// (ordering is not guaranteed due to goroutine scheduling, so just check for a total of 9 packets)
+	wgs.Add(cc * 3)
+	for i := 0; i < cc; i++ {
+		sendStr := fmt.Sprintf("hello %d", i)
+
+		idx := i
+		go func() {
+			for j := 0; j < 2; j++ {
+				_, err := clients[idx].Write([]byte(sendStr))
+				assert.NoError(t, err)
+			}
+
+			buf := make([]byte, 1400)
+			for j := 0; ; j++ {
+				err := clients[idx].SetReadDeadline(time.Now().Add(time.Second))
+				assert.NoError(t, err)
+
+				n, err := clients[idx].Read(buf)
+				if err == nil {
+					assert.Equal(t, sendStr, string(buf[:n]), "mismatch in first read, client: %d, packet: %d", idx, j)
+					wgs.Done()
+				} else {
+					break
+				}
+			}
+		}()
+	}
+	wgs.Wait()
+
+	// should not be able to read any packets as the next batch is not ready yet
+	wgs.Add(cc)
+	for i := 0; i < cc; i++ {
+		idx := i
+		go func() {
+			defer wgs.Done()
+
+			err := clients[idx].SetReadDeadline(time.Now().Add(time.Second))
+			assert.NoError(t, err)
+
+			buf := make([]byte, 1400)
+			n, err := clients[idx].Read(buf)
+			assert.Zero(t, n, "unexpected packet from client: %d", idx)
+			assert.ErrorContains(t, err, "timeout", "expected timeout from client: %d", idx)
+		}()
+	}
+	wgs.Wait()
+
+	// third cycle, write two packets from each client,
+	// should be able to read three packets on average per client
+	wgs.Add(cc * 3)
+	for i := 0; i < cc; i++ {
+		sendStr := fmt.Sprintf("hello %d", i)
+
+		idx := i
+		go func() {
+			defer func() { _ = clients[idx].Close() }()
+
+			for j := 0; j < 2; j++ {
+				_, err := clients[idx].Write([]byte(sendStr))
+				assert.NoError(t, err)
+			}
+
+			buf := make([]byte, 1400)
+			for j := 0; ; j++ {
+				err := clients[idx].SetReadDeadline(time.Now().Add(time.Second))
+				assert.NoError(t, err)
+
+				n, err := clients[idx].Read(buf)
+				if err == nil {
+					assert.Equal(t, sendStr, string(buf[:n]), "mismatch in second read, client: %d, packet: %d", idx, j)
+					wgs.Done()
+				} else {
+					break
+				}
+			}
+		}()
+	}
+	wgs.Wait()
+
+	_ = listener.Close()
+	serverConnWg.Wait()
+}

--- a/udp/conn_test.go
+++ b/udp/conn_test.go
@@ -419,7 +419,7 @@ func TestBatchIO(t *testing.T) {
 
 	var serverConnWg sync.WaitGroup
 	serverConnWg.Add(1)
-	go func() {
+	go func() { //nolint:dupl
 		var exit int32
 		defer func() {
 			defer serverConnWg.Done()
@@ -484,7 +484,7 @@ func TestBatchIO(t *testing.T) {
 				assert.NoError(t, err)
 				n, err := client.Read(buf)
 				assert.NoError(t, err)
-				assert.Equal(t, sendStr, string(buf[:n]), i)
+				assert.Equal(t, sendStr, string(buf[:n]), "mismatch in client: %d", i)
 			}
 		}()
 	}


### PR DESCRIPTION
#### Description

To prevent writes from getting blocked while flushing the batch, switching to a ping-pong buffer.
