### PR TITLE
Resolve the empty address to INADDR_ANY in VNet

### DIFF
--- a/vnet/net.go
+++ b/vnet/net.go
@@ -320,6 +320,10 @@ func (v *Net) Dial(network string, address string) (net.Conn, error) {
 func (v *Net) ResolveIPAddr(_, address string) (*net.IPAddr, error) {
 	var err error
 
+	if address == "" {
+		address = "0.0.0.0"
+	}
+
 	// Check if host is a domain name
 	ip := net.ParseIP(address)
 	if ip == nil { //nolint:nestif

--- a/vnet/net.go
+++ b/vnet/net.go
@@ -19,8 +19,15 @@ import (
 
 const (
 	lo0String = "lo0String"
+	ip        = "ip"
+	ip4       = "ip4"
+	ip6       = "ip6"
 	udp       = "udp"
 	udp4      = "udp4"
+	udp6      = "udp6"
+	tcp       = "tcp"
+	tcp4      = "tcp4"
+	tcp6      = "tcp6"
 )
 
 var (
@@ -317,8 +324,22 @@ func (v *Net) Dial(network string, address string) (net.Conn, error) {
 }
 
 // ResolveIPAddr returns an address of IP end point.
-func (v *Net) ResolveIPAddr(_, address string) (*net.IPAddr, error) {
+func (v *Net) ResolveIPAddr(network, address string) (*net.IPAddr, error) {
 	var err error
+
+	switch network {
+	case "", ip, ip4, ip6:
+	default:
+		return nil, fmt.Errorf("%w %s", errUnknownNetwork, network)
+	}
+
+	if address == "" {
+		if network == ip6 {
+			return &net.IPAddr{IP: net.IPv6unspecified}, nil
+		}
+
+		return &net.IPAddr{IP: net.IPv4zero}, nil
+	}
 
 	// Check if host is a domain name
 	ip := net.ParseIP(address)
@@ -346,7 +367,13 @@ func (v *Net) ResolveIPAddr(_, address string) (*net.IPAddr, error) {
 
 // ResolveUDPAddr returns an address of UDP end point.
 func (v *Net) ResolveUDPAddr(network, address string) (*net.UDPAddr, error) {
-	if network != udp && network != udp4 {
+	var ipNetwork string
+	switch network {
+	case udp, udp4:
+		ipNetwork = ip4
+	case udp6:
+		ipNetwork = ip6
+	default:
 		return nil, fmt.Errorf("%w %s", errUnknownNetwork, network)
 	}
 
@@ -355,7 +382,7 @@ func (v *Net) ResolveUDPAddr(network, address string) (*net.UDPAddr, error) {
 		return nil, err
 	}
 
-	ipAddress, err := v.ResolveIPAddr("ip", host)
+	ipAddress, err := v.ResolveIPAddr(ipNetwork, host)
 	if err != nil {
 		return nil, err
 	}
@@ -376,7 +403,13 @@ func (v *Net) ResolveUDPAddr(network, address string) (*net.UDPAddr, error) {
 
 // ResolveTCPAddr returns an address of TCP end point.
 func (v *Net) ResolveTCPAddr(network, address string) (*net.TCPAddr, error) {
-	if network != udp && network != "udp4" {
+	var ipNetwork string
+	switch network {
+	case tcp, tcp4:
+		ipNetwork = ip4
+	case tcp6:
+		ipNetwork = ip6
+	default:
 		return nil, fmt.Errorf("%w %s", errUnknownNetwork, network)
 	}
 
@@ -385,7 +418,7 @@ func (v *Net) ResolveTCPAddr(network, address string) (*net.TCPAddr, error) {
 		return nil, err
 	}
 
-	ipAddr, err := v.ResolveIPAddr("ip", host)
+	ipAddr, err := v.ResolveIPAddr(ipNetwork, host)
 	if err != nil {
 		return nil, err
 	}

--- a/vnet/net_test.go
+++ b/vnet/net_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/transport/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNetVirtual(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
@@ -280,6 +281,27 @@ func TestNetVirtual(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			return
 		}
 		assert.Equal(t, "127.0.0.1", udpAddr.IP.String(), "should match")
+		assert.Equal(t, 1234, udpAddr.Port, "should match")
+	})
+
+	t.Run("ResolveEmptyAddr", func(t *testing.T) {
+		nw, err := NewNet(&NetConfig{})
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+
+		wan, err := NewRouter(&RouterConfig{
+			CIDR:          "1.2.3.0/24",
+			LoggerFactory: loggerFactory,
+		})
+		require.NoError(t, err, "should succeed")
+		require.NoError(t, wan.AddNet(nw), "should succeed")
+
+		udpAddr, err := nw.ResolveUDPAddr(udp, ":1234")
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+		assert.Equal(t, "0.0.0.0", udpAddr.IP.String(), "should match")
 		assert.Equal(t, 1234, udpAddr.Port, "should match")
 	})
 

--- a/vnet/net_test.go
+++ b/vnet/net_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pion/logging"
 	"github.com/pion/transport/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNetVirtual(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
@@ -280,6 +281,59 @@ func TestNetVirtual(t *testing.T) { //nolint:gocyclo,cyclop,maintidx
 			return
 		}
 		assert.Equal(t, "127.0.0.1", udpAddr.IP.String(), "should match")
+		assert.Equal(t, 1234, udpAddr.Port, "should match")
+	})
+
+	t.Run("ResolveEmptyAddr", func(t *testing.T) {
+		nw, err := NewNet(&NetConfig{})
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+
+		wan, err := NewRouter(&RouterConfig{
+			CIDR:          "1.2.3.0/24",
+			LoggerFactory: loggerFactory,
+		})
+		require.NoError(t, err, "should succeed")
+		require.NoError(t, wan.AddNet(nw), "should succeed")
+
+		ipAddr, err := nw.ResolveIPAddr(ip, "")
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+		assert.Equal(t, "0.0.0.0", ipAddr.IP.String(), "should match")
+
+		ipAddr, err = nw.ResolveIPAddr(ip4, "")
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+		assert.Equal(t, "0.0.0.0", ipAddr.IP.String(), "should match")
+
+		ipAddr, err = nw.ResolveIPAddr(ip6, "")
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+		assert.Equal(t, "::", ipAddr.IP.String(), "should match")
+
+		udpAddr, err := nw.ResolveUDPAddr(udp, ":1234")
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+		assert.Equal(t, "0.0.0.0", udpAddr.IP.String(), "should match")
+		assert.Equal(t, 1234, udpAddr.Port, "should match")
+
+		udpAddr, err = nw.ResolveUDPAddr(udp4, ":1234")
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+		assert.Equal(t, "0.0.0.0", udpAddr.IP.String(), "should match")
+		assert.Equal(t, 1234, udpAddr.Port, "should match")
+
+		udpAddr, err = nw.ResolveUDPAddr(udp6, ":1234")
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+		assert.Equal(t, "::", udpAddr.IP.String(), "should match")
 		assert.Equal(t, 1234, udpAddr.Port, "should match")
 	})
 


### PR DESCRIPTION
#### Description

So far calling `VNet.ListenPacket("udp4", ":1234")` with the shorthand empty address has failed by "host not found" in `VNet.ResolveIPAddr`. 

This PR makes sure the empty address resolves to `INADDR_ANY`. 