### PR TITLE
Fix TCP chunk: seqNum/ackNum and Clone

### DIFF
--- a/vnet/chunk.go
+++ b/vnet/chunk.go
@@ -81,7 +81,7 @@ type chunkIP struct {
 	duplicate     bool
 }
 
-func (c *chunkIP) setTimestamp() time.Time {
+func (c *chunkIP) setTimestamp() time.Time { // nolint:unparam
 	c.timestamp = time.Now()
 
 	return c.timestamp
@@ -212,8 +212,8 @@ type chunkTCP struct {
 	destinationPort int
 	flags           tcpFlag // control bits
 	userData        []byte  // only with PSH flag
-	// seq             uint32  // always starts with 0
-	// ack             uint32  // always starts with 0
+	seqNum          uint32  // data sequence (vnet-internal)
+	ackNum          uint32  // ACK for a seqNum (vnet-internal)
 }
 
 func newChunkTCP(srcAddr, dstAddr *net.TCPAddr, flags tcpFlag) *chunkTCP {
@@ -256,15 +256,20 @@ func (c *chunkTCP) Clone() Chunk {
 			timestamp:     c.timestamp,
 			sourceIP:      c.sourceIP,
 			destinationIP: c.destinationIP,
+			tag:           c.tag,
+			duplicate:     c.duplicate,
 		},
 		sourcePort:      c.sourcePort,
 		destinationPort: c.destinationPort,
+		flags:           c.flags,
 		userData:        userData,
+		seqNum:          c.seqNum,
+		ackNum:          c.ackNum,
 	}
 }
 
 func (c *chunkTCP) Network() string {
-	return "tcp"
+	return tcp
 }
 
 func (c *chunkTCP) String() string {

--- a/vnet/chunk_test.go
+++ b/vnet/chunk_test.go
@@ -12,6 +12,95 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestChunkUDPClone(t *testing.T) {
+	src := &net.UDPAddr{IP: net.ParseIP("10.0.0.1"), Port: 1111}
+	dst := &net.UDPAddr{IP: net.ParseIP("10.0.0.2"), Port: 2222}
+
+	t.Run("AllFieldsCopied", func(t *testing.T) {
+		orig := newChunkUDP(src, dst)
+		orig.userData = []byte("hello")
+		orig.setTimestamp()
+
+		cloned := orig.Clone().(*chunkUDP) //nolint:forcetypeassert
+
+		assert.Equal(t, orig.sourceIP.String(), cloned.sourceIP.String())
+		assert.Equal(t, orig.destinationIP.String(), cloned.destinationIP.String())
+		assert.Equal(t, orig.sourcePort, cloned.sourcePort)
+		assert.Equal(t, orig.destinationPort, cloned.destinationPort)
+		assert.Equal(t, orig.tag, cloned.tag)
+		assert.Equal(t, orig.timestamp, cloned.timestamp)
+		assert.Equal(t, orig.userData, cloned.userData)
+	})
+
+	t.Run("UserDataDeepCopy", func(t *testing.T) {
+		orig := newChunkUDP(src, dst)
+		orig.userData = []byte("hello")
+
+		cloned := orig.Clone().(*chunkUDP) //nolint:forcetypeassert
+
+		orig.userData[0] = 'X'
+		assert.Equal(t, byte('h'), cloned.userData[0], "clone should not be affected by mutation of original userData")
+	})
+
+	t.Run("NilUserData", func(t *testing.T) {
+		orig := newChunkUDP(src, dst)
+		// userData is nil by default
+
+		cloned := orig.Clone().(*chunkUDP) //nolint:forcetypeassert
+
+		assert.Nil(t, cloned.userData)
+	})
+}
+
+func TestChunkTCPClone(t *testing.T) {
+	src := &net.TCPAddr{IP: net.ParseIP("10.0.0.1"), Port: 1111}
+	dst := &net.TCPAddr{IP: net.ParseIP("10.0.0.2"), Port: 2222}
+
+	t.Run("AllFieldsCopied", func(t *testing.T) {
+		orig := newChunkTCP(src, dst, tcpSYN|tcpACK)
+		orig.userData = []byte("hello")
+		orig.seqNum = 42
+		orig.ackNum = 99
+		orig.duplicate = true
+		orig.setTimestamp()
+
+		cloned := orig.Clone().(*chunkTCP) //nolint:forcetypeassert
+
+		assert.Equal(t, orig.sourceIP.String(), cloned.sourceIP.String())
+		assert.Equal(t, orig.destinationIP.String(), cloned.destinationIP.String())
+		assert.Equal(t, orig.sourcePort, cloned.sourcePort)
+		assert.Equal(t, orig.destinationPort, cloned.destinationPort)
+		assert.Equal(t, orig.tag, cloned.tag)
+		assert.Equal(t, orig.timestamp, cloned.timestamp)
+		assert.Equal(t, orig.flags, cloned.flags)
+		assert.Equal(t, orig.seqNum, cloned.seqNum)
+		assert.Equal(t, orig.ackNum, cloned.ackNum)
+		assert.Equal(t, orig.duplicate, cloned.duplicate)
+		assert.Equal(t, orig.userData, cloned.userData)
+	})
+
+	t.Run("UserDataDeepCopy", func(t *testing.T) {
+		orig := newChunkTCP(src, dst, tcpPSH)
+		orig.userData = []byte("hello")
+
+		cloned := orig.Clone().(*chunkTCP) //nolint:forcetypeassert
+
+		orig.userData[0] = 'X'
+		assert.Equal(t, byte('h'), cloned.userData[0], "clone should not be affected by mutation of original userData")
+	})
+
+	t.Run("IndependentAddrs", func(t *testing.T) {
+		orig := newChunkTCP(src, dst, tcpSYN)
+
+		cloned := orig.Clone().(*chunkTCP) //nolint:forcetypeassert
+
+		assert.NoError(t, orig.setSourceAddr("9.9.9.9:9999"))
+		assert.Equal(t, "10.0.0.1:1111", cloned.SourceAddr().String(), "clone source addr should be unchanged")
+		assert.NoError(t, orig.setDestinationAddr("8.8.8.8:8888"))
+		assert.Equal(t, "10.0.0.2:2222", cloned.DestinationAddr().String(), "clone destination addr should be unchanged")
+	})
+}
+
 func TestTCPFragString(t *testing.T) {
 	f := tcpFIN
 	assert.Equal(t, "FIN", f.String(), "should match")
@@ -90,7 +179,7 @@ func TestChunk(t *testing.T) {
 		var chunk Chunk = newChunkTCP(src, dst, tcpSYN)
 		str := chunk.String()
 		log.Debugf("chunk: %s", str)
-		assert.Equal(t, "tcp", chunk.Network(), "should match")
+		assert.Equal(t, tcp, chunk.Network(), "should match")
 		assert.True(t, strings.Contains(str, src.Network()), "should include network type")
 		assert.True(t, strings.Contains(str, src.String()), "should include address")
 		assert.True(t, strings.Contains(str, dst.String()), "should include address")


### PR DESCRIPTION
#### Description

Self-contained improvements to the existing `chunkTCP` struct.
- Add `seqNum` and `ackNum` fields (replacing commented-out stubs).
- Fix `Clone()` to copy `flags`, `seqNum`, `ackNum`, `tag`, and `duplicate` — previously these were silently dropped on clone.
- Use the `tcp` package constant in `Network()` instead of raw string `"tcp"`.

Split out from https://github.com/pion/transport/pull/375