### PR TITLE
Add TCP connection and listener tracking maps

### DIFF
--- a/vnet/tcp_conn.go
+++ b/vnet/tcp_conn.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package vnet
+
+import (
+	"io"
+	"net"
+	"time"
+
+	"github.com/pion/transport/v4"
+)
+
+// TCPConn implements transport.TCPConn.
+type TCPConn struct {
+	locAddr *net.TCPAddr
+	remAddr *net.TCPAddr
+}
+
+var _ transport.TCPConn = &TCPConn{}
+
+// Read reads data from the connection.
+func (c *TCPConn) Read(b []byte) (int, error) {
+	return 0, transport.ErrNotSupported
+}
+
+// Write writes data to the connection.
+func (c *TCPConn) Write(b []byte) (int, error) {
+	return 0, transport.ErrNotSupported
+}
+
+// Close closes the connection.
+func (c *TCPConn) Close() error {
+	return transport.ErrNotSupported
+}
+
+// CloseRead closes the read side of the connection.
+func (c *TCPConn) CloseRead() error {
+	return transport.ErrNotSupported
+}
+
+// CloseWrite closes the write side of the connection.
+func (c *TCPConn) CloseWrite() error {
+	return transport.ErrNotSupported
+}
+
+// LocalAddr returns the local network address.
+func (c *TCPConn) LocalAddr() net.Addr {
+	return c.locAddr
+}
+
+// RemoteAddr returns the remote network address.
+func (c *TCPConn) RemoteAddr() net.Addr {
+	return c.remAddr
+}
+
+// SetDeadline sets the read and write deadlines associated with the connection.
+func (c *TCPConn) SetDeadline(t time.Time) error {
+	return transport.ErrNotSupported
+}
+
+// SetReadDeadline sets the deadline for future Read calls.
+func (c *TCPConn) SetReadDeadline(t time.Time) error {
+	return transport.ErrNotSupported
+}
+
+// SetWriteDeadline sets the deadline for future Write calls.
+func (c *TCPConn) SetWriteDeadline(t time.Time) error {
+	return transport.ErrNotSupported
+}
+
+// ReadFrom reads data from r and writes it to the connection.
+func (c *TCPConn) ReadFrom(r io.Reader) (int64, error) {
+	return 0, transport.ErrNotSupported
+}
+
+// SetLinger sets the behavior of Close method on a connection with pending data.
+func (c *TCPConn) SetLinger(int) error {
+	return transport.ErrNotSupported
+}
+
+// SetKeepAlive enables or disables the keep-alive functionality for this connection.
+func (c *TCPConn) SetKeepAlive(bool) error {
+	return transport.ErrNotSupported
+}
+
+// SetKeepAlivePeriod sets the period between keep-alive messages for this connection.
+func (c *TCPConn) SetKeepAlivePeriod(time.Duration) error {
+	return transport.ErrNotSupported
+}
+
+// SetNoDelay enables or disables the Nagle's algorithm for this connection.
+func (c *TCPConn) SetNoDelay(bool) error {
+	return transport.ErrNotSupported
+}
+
+// SetWriteBuffer sets the size of the operating system's transmit buffer associated
+// with the connection.
+func (c *TCPConn) SetWriteBuffer(int) error {
+	return transport.ErrNotSupported
+}
+
+// SetReadBuffer sets the size of the operating system's receive buffer associated
+// with the connection.
+func (c *TCPConn) SetReadBuffer(int) error {
+	return transport.ErrNotSupported
+}

--- a/vnet/tcp_listener.go
+++ b/vnet/tcp_listener.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package vnet
+
+import (
+	"net"
+	"time"
+
+	"github.com/pion/transport/v4"
+)
+
+// TCPListener implements transport.TCPListener.
+type TCPListener struct {
+	locAddr *net.TCPAddr
+}
+
+var _ transport.TCPListener = &TCPListener{}
+
+// Accept waits for and returns the next connection to the listener.
+func (l *TCPListener) Accept() (net.Conn, error) {
+	return nil, transport.ErrNotSupported
+}
+
+// AcceptTCP waits for and returns the next TCP connection to the listener.
+func (l *TCPListener) AcceptTCP() (transport.TCPConn, error) {
+	return nil, transport.ErrNotSupported
+}
+
+// Close closes the listener. Any blocked Accept operations will be unblocked and return errors.
+func (l *TCPListener) Close() error {
+	return transport.ErrNotSupported
+}
+
+// Addr returns the listener's network address.
+func (l *TCPListener) Addr() net.Addr {
+	return l.locAddr
+}
+
+// SetDeadline sets the deadline for future Accept calls.
+func (l *TCPListener) SetDeadline(t time.Time) error {
+	return transport.ErrNotSupported
+}

--- a/vnet/tcp_map.go
+++ b/vnet/tcp_map.go
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package vnet
+
+import (
+	"errors"
+	"net"
+	"sync"
+)
+
+var (
+	errNoSuchTCPConn      = errors.New("no such TCPConn")
+	errNoSuchTCPListener  = errors.New("no such TCPListener")
+	errTCPConnAlreadyUsed = errors.New("tcp connection tuple already in use")
+)
+
+type tcpListenerMap struct {
+	portMap map[int][]*TCPListener
+	mutex   sync.RWMutex
+}
+
+func newTCPListenerMap() *tcpListenerMap {
+	return &tcpListenerMap{portMap: map[int][]*TCPListener{}}
+}
+
+func (m *tcpListenerMap) insert(listener *TCPListener) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	addr := listener.Addr().(*net.TCPAddr) //nolint:forcetypeassert
+
+	listeners, ok := m.portMap[addr.Port]
+	if ok {
+		if addr.IP.IsUnspecified() {
+			return errAddressAlreadyInUse
+		}
+		for _, existing := range listeners {
+			eaddr := existing.Addr().(*net.TCPAddr) //nolint:forcetypeassert
+			if eaddr.IP.IsUnspecified() || eaddr.IP.Equal(addr.IP) {
+				return errAddressAlreadyInUse
+			}
+		}
+		listeners = append(listeners, listener)
+	} else {
+		listeners = []*TCPListener{listener}
+	}
+
+	m.portMap[addr.Port] = listeners
+
+	return nil
+}
+
+func (m *tcpListenerMap) find(addr *net.TCPAddr) (*TCPListener, bool) {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	listeners, ok := m.portMap[addr.Port]
+	if !ok {
+		return nil, false
+	}
+
+	if addr.IP.IsUnspecified() {
+		if len(listeners) == 0 {
+			return nil, false
+		}
+
+		return listeners[0], true
+	}
+
+	for _, l := range listeners {
+		eaddr := l.Addr().(*net.TCPAddr) //nolint:forcetypeassert
+		if eaddr.IP.IsUnspecified() || eaddr.IP.Equal(addr.IP) {
+			return l, true
+		}
+	}
+
+	return nil, false
+}
+
+func (m *tcpListenerMap) delete(addr net.Addr) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	tcpAddr := addr.(*net.TCPAddr) //nolint:forcetypeassert
+	listeners, ok := m.portMap[tcpAddr.Port]
+	if !ok {
+		return errNoSuchTCPListener
+	}
+
+	if tcpAddr.IP.IsUnspecified() {
+		// insert() prevents any other listener from sharing a port with a
+		// 0.0.0.0 listener, so there is exactly one entry for this port.
+		// Deleting the whole port slot is therefore always correct here.
+		delete(m.portMap, tcpAddr.Port)
+
+		return nil
+	}
+
+	newListeners := make([]*TCPListener, 0, len(listeners))
+	removed := false
+	for _, l := range listeners {
+		eaddr := l.Addr().(*net.TCPAddr) //nolint:forcetypeassert
+		if eaddr.IP.Equal(tcpAddr.IP) {
+			removed = true
+
+			continue
+		}
+		newListeners = append(newListeners, l)
+	}
+
+	if !removed {
+		return errNoSuchTCPListener
+	}
+
+	if len(newListeners) == 0 {
+		delete(m.portMap, tcpAddr.Port)
+	} else {
+		m.portMap[tcpAddr.Port] = newListeners
+	}
+
+	return nil
+}
+
+type tcpConnMap struct {
+	portMap map[int][]*TCPConn
+	mutex   sync.RWMutex
+}
+
+func newTCPConnMap() *tcpConnMap {
+	return &tcpConnMap{portMap: map[int][]*TCPConn{}}
+}
+
+func (m *tcpConnMap) insert(conn *TCPConn) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	laddr := conn.LocalAddr().(*net.TCPAddr)  //nolint:forcetypeassert
+	raddr := conn.RemoteAddr().(*net.TCPAddr) //nolint:forcetypeassert
+
+	conns := m.portMap[laddr.Port]
+	for _, existing := range conns {
+		eL := existing.LocalAddr().(*net.TCPAddr)  //nolint:forcetypeassert
+		eR := existing.RemoteAddr().(*net.TCPAddr) //nolint:forcetypeassert
+		if (eL.IP.IsUnspecified() || laddr.IP.IsUnspecified() || eL.IP.Equal(laddr.IP)) &&
+			eR.IP.Equal(raddr.IP) && eR.Port == raddr.Port {
+			return errTCPConnAlreadyUsed
+		}
+	}
+
+	m.portMap[laddr.Port] = append(conns, conn)
+
+	return nil
+}
+
+func (m *tcpConnMap) findByChunk(tcp *chunkTCP) (*TCPConn, bool) {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	dst := tcp.DestinationAddr().(*net.TCPAddr) //nolint:forcetypeassert
+	src := tcp.SourceAddr().(*net.TCPAddr)      //nolint:forcetypeassert
+
+	conns, ok := m.portMap[dst.Port]
+	if !ok {
+		return nil, false
+	}
+
+	for _, c := range conns {
+		laddr := c.LocalAddr().(*net.TCPAddr)  //nolint:forcetypeassert
+		raddr := c.RemoteAddr().(*net.TCPAddr) //nolint:forcetypeassert
+		if (laddr.IP.IsUnspecified() || laddr.IP.Equal(dst.IP)) && raddr.IP.Equal(src.IP) && raddr.Port == src.Port {
+			return c, true
+		}
+	}
+
+	return nil, false
+}
+
+func (m *tcpConnMap) deleteConn(c *TCPConn) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	laddr := c.LocalAddr().(*net.TCPAddr) //nolint:forcetypeassert
+	conns, ok := m.portMap[laddr.Port]
+	if !ok {
+		return errNoSuchTCPConn
+	}
+
+	newConns := []*TCPConn{}
+	for _, existing := range conns {
+		if existing == c {
+			continue
+		}
+		newConns = append(newConns, existing)
+	}
+
+	if len(newConns) == len(conns) {
+		return errNoSuchTCPConn
+	}
+	if len(newConns) == 0 {
+		delete(m.portMap, laddr.Port)
+	} else {
+		m.portMap[laddr.Port] = newConns
+	}
+
+	return nil
+}
+
+func (m *tcpConnMap) deleteByAddr(laddr, raddr *net.TCPAddr) error {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	conns, ok := m.portMap[laddr.Port]
+	if !ok {
+		return errNoSuchTCPConn
+	}
+
+	newConns := make([]*TCPConn, 0, len(conns))
+	for _, c := range conns {
+		claddr := c.LocalAddr().(*net.TCPAddr)  //nolint:forcetypeassert
+		craddr := c.RemoteAddr().(*net.TCPAddr) //nolint:forcetypeassert
+		if claddr.IP.Equal(laddr.IP) && craddr.IP.Equal(raddr.IP) && craddr.Port == raddr.Port {
+			continue // remove — full 4-tuple match
+		}
+		newConns = append(newConns, c)
+	}
+
+	if len(newConns) == len(conns) {
+		return errNoSuchTCPConn
+	}
+	if len(newConns) == 0 {
+		delete(m.portMap, laddr.Port)
+	} else {
+		m.portMap[laddr.Port] = newConns
+	}
+
+	return nil
+}
+
+func (m *tcpConnMap) portInUse(ip net.IP, port int) bool {
+	m.mutex.RLock()
+	defer m.mutex.RUnlock()
+
+	conns, ok := m.portMap[port]
+	if !ok {
+		return false
+	}
+	for _, c := range conns {
+		laddr := c.LocalAddr().(*net.TCPAddr) //nolint:forcetypeassert
+		if laddr.IP.IsUnspecified() || laddr.IP.Equal(ip) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/vnet/tcp_map_test.go
+++ b/vnet/tcp_map_test.go
@@ -1,0 +1,434 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package vnet
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestTCPListener(ip string, port int) *TCPListener {
+	return &TCPListener{
+		locAddr: &net.TCPAddr{IP: net.ParseIP(ip), Port: port},
+	}
+}
+
+func newTestTCPConn(locIP string, locPort int, remIP string, remPort int) *TCPConn {
+	return &TCPConn{
+		locAddr: &net.TCPAddr{IP: net.ParseIP(locIP), Port: locPort},
+		remAddr: &net.TCPAddr{IP: net.ParseIP(remIP), Port: remPort},
+	}
+}
+
+func findTCPConnByTuple(m *tcpConnMap, dstIP string, dstPort int, srcIP string, srcPort int) (*TCPConn, bool) {
+	c := newChunkTCP(
+		&net.TCPAddr{IP: net.ParseIP(srcIP), Port: srcPort},
+		&net.TCPAddr{IP: net.ParseIP(dstIP), Port: dstPort},
+		tcpACK,
+	)
+
+	return m.findByChunk(c)
+}
+
+func TestTCPListenerMap(t *testing.T) {
+	t.Run("insert a TCPListener and remove it", func(t *testing.T) {
+		listenerMap := newTCPListenerMap()
+
+		l1 := newTestTCPListener("127.0.0.1", 1234)
+		err := listenerMap.insert(l1)
+		assert.NoError(t, err, "should succeed")
+
+		out, ok := listenerMap.find(l1.Addr().(*net.TCPAddr)) //nolint:forcetypeassert
+		assert.True(t, ok, "should succeed")
+		assert.Equal(t, l1, out, "should match")
+		assert.Equal(t, 1, len(listenerMap.portMap), "should match")
+
+		err = listenerMap.delete(l1.Addr())
+		assert.NoError(t, err, "should succeed")
+		assert.Empty(t, listenerMap.portMap, "should match")
+
+		err = listenerMap.delete(l1.Addr())
+		assert.Error(t, err, "should fail")
+	})
+
+	t.Run("insert a TCPListener on 0.0.0.0 and remove it", func(t *testing.T) {
+		listenerMap := newTCPListenerMap()
+
+		l1 := newTestTCPListener("0.0.0.0", 1234)
+		err := listenerMap.insert(l1)
+		assert.NoError(t, err, "should succeed")
+
+		out, ok := listenerMap.find(l1.Addr().(*net.TCPAddr)) //nolint:forcetypeassert
+		assert.True(t, ok, "should succeed")
+		assert.Equal(t, l1, out, "should match")
+		assert.Equal(t, 1, len(listenerMap.portMap), "should match")
+
+		err = listenerMap.delete(l1.Addr())
+		assert.NoError(t, err, "should succeed")
+
+		err = listenerMap.delete(l1.Addr())
+		assert.Error(t, err, "should fail")
+	})
+
+	t.Run("find TCPListener on 0.0.0.0 by specified IP", func(t *testing.T) {
+		listenerMap := newTCPListenerMap()
+
+		l1 := newTestTCPListener("0.0.0.0", 1234)
+		err := listenerMap.insert(l1)
+		assert.NoError(t, err, "should succeed")
+
+		out, ok := listenerMap.find(&net.TCPAddr{IP: net.ParseIP("192.168.0.1"), Port: 1234})
+		assert.True(t, ok, "should succeed")
+		assert.Equal(t, l1, out, "should match")
+		assert.Equal(t, 1, len(listenerMap.portMap), "should match")
+	})
+
+	t.Run("insert many IPs with the same port", func(t *testing.T) {
+		listenerMap := newTCPListenerMap()
+
+		l1 := newTestTCPListener("10.1.2.1", 5678)
+		err := listenerMap.insert(l1)
+		assert.NoError(t, err, "should succeed")
+
+		l2 := newTestTCPListener("10.1.2.2", 5678)
+		err = listenerMap.insert(l2)
+		assert.NoError(t, err, "should succeed")
+
+		out1, ok := listenerMap.find(&net.TCPAddr{IP: net.ParseIP("10.1.2.1"), Port: 5678})
+		assert.True(t, ok, "should succeed")
+		assert.Equal(t, l1, out1, "should match")
+
+		out2, ok := listenerMap.find(&net.TCPAddr{IP: net.ParseIP("10.1.2.2"), Port: 5678})
+		assert.True(t, ok, "should succeed")
+		assert.Equal(t, l2, out2, "should match")
+
+		assert.Equal(t, 1, len(listenerMap.portMap), "should match")
+	})
+
+	t.Run("already in-use when inserting 0.0.0.0", func(t *testing.T) {
+		listenerMap := newTCPListenerMap()
+
+		l1 := newTestTCPListener("10.1.2.1", 5678)
+		err := listenerMap.insert(l1)
+		assert.NoError(t, err, "should succeed")
+
+		l2 := newTestTCPListener("0.0.0.0", 5678)
+		err = listenerMap.insert(l2)
+		assert.Error(t, err, "should fail")
+	})
+
+	t.Run("already in-use when inserting a specified IP", func(t *testing.T) {
+		listenerMap := newTCPListenerMap()
+
+		l1 := newTestTCPListener("0.0.0.0", 5678)
+		err := listenerMap.insert(l1)
+		assert.NoError(t, err, "should succeed")
+
+		l2 := newTestTCPListener("192.168.0.1", 5678)
+		err = listenerMap.insert(l2)
+		assert.Error(t, err, "should fail")
+	})
+
+	t.Run("already in-use when inserting the same specified IP", func(t *testing.T) {
+		listenerMap := newTCPListenerMap()
+
+		l1 := newTestTCPListener("192.168.0.1", 5678)
+		err := listenerMap.insert(l1)
+		assert.NoError(t, err, "should succeed")
+
+		l2 := newTestTCPListener("192.168.0.1", 5678)
+		err = listenerMap.insert(l2)
+		assert.Error(t, err, "should fail")
+	})
+
+	t.Run("find failure 1", func(t *testing.T) {
+		listenerMap := newTCPListenerMap()
+
+		l1 := newTestTCPListener("192.168.0.1", 5678)
+		err := listenerMap.insert(l1)
+		assert.NoError(t, err, "should succeed")
+
+		_, ok := listenerMap.find(&net.TCPAddr{IP: net.ParseIP("192.168.0.2"), Port: 5678})
+		assert.False(t, ok, "should fail")
+	})
+
+	t.Run("find failure 2", func(t *testing.T) {
+		listenerMap := newTCPListenerMap()
+
+		l1 := newTestTCPListener("192.168.0.1", 5678)
+		err := listenerMap.insert(l1)
+		assert.NoError(t, err, "should succeed")
+
+		_, ok := listenerMap.find(&net.TCPAddr{IP: net.ParseIP("192.168.0.1"), Port: 1234})
+		assert.False(t, ok, "should fail")
+	})
+
+	t.Run("insert two TCPListeners on the same port, then remove them", func(t *testing.T) {
+		listenerMap := newTCPListenerMap()
+
+		l1 := newTestTCPListener("192.168.0.1", 5678)
+		err := listenerMap.insert(l1)
+		assert.NoError(t, err, "should succeed")
+
+		l2 := newTestTCPListener("192.168.0.2", 5678)
+		err = listenerMap.insert(l2)
+		assert.NoError(t, err, "should succeed")
+
+		err = listenerMap.delete(l1.Addr())
+		assert.NoError(t, err, "should succeed")
+
+		err = listenerMap.delete(l2.Addr())
+		assert.NoError(t, err, "should succeed")
+	})
+
+	t.Run("delete returns error when IP not found in non-empty port slot", func(t *testing.T) {
+		// The port slot exists (l1 is registered), but the IP being deleted does
+		// not match any entry. The removed flag stays false and the function must
+		// return errNoSuchTCPListener.
+		listenerMap := newTCPListenerMap()
+
+		l1 := newTestTCPListener("192.168.0.1", 5678)
+		err := listenerMap.insert(l1)
+		assert.NoError(t, err, "should succeed")
+
+		absent := &net.TCPAddr{IP: net.ParseIP("192.168.0.99"), Port: 5678}
+		err = listenerMap.delete(absent)
+		assert.ErrorIs(t, err, errNoSuchTCPListener, "should fail — IP not in port slot")
+
+		// l1 must still be present after the failed delete.
+		out, ok := listenerMap.find(l1.Addr().(*net.TCPAddr)) //nolint:forcetypeassert
+		assert.True(t, ok, "l1 should still be findable")
+		assert.Equal(t, l1, out, "should match l1")
+	})
+}
+
+func TestTCPConnMap(t *testing.T) {
+	t.Run("insert a TCPConn and remove it", func(t *testing.T) {
+		connMap := newTCPConnMap()
+
+		c1 := newTestTCPConn("127.0.0.1", 1234, "127.0.0.1", 5678)
+		err := connMap.insert(c1)
+		assert.NoError(t, err, "should succeed")
+
+		out, ok := findTCPConnByTuple(connMap, "127.0.0.1", 1234, "127.0.0.1", 5678)
+		assert.True(t, ok, "should succeed")
+		assert.Equal(t, c1, out, "should match")
+		assert.Equal(t, 1, len(connMap.portMap), "should match")
+
+		err = connMap.deleteConn(c1)
+		assert.NoError(t, err, "should succeed")
+		assert.Empty(t, connMap.portMap, "should match")
+
+		err = connMap.deleteConn(c1)
+		assert.Error(t, err, "should fail")
+	})
+
+	t.Run("deleteConn returns error when conn is absent but port slot still exists", func(t *testing.T) {
+		// c1 and c2 share a local port. After c1 is deleted, a second delete of
+		// c1 must return errNoSuchTCPConn even though c2 keeps the port slot alive.
+		connMap := newTCPConnMap()
+
+		c1 := newTestTCPConn("10.0.0.1", 5000, "10.0.0.2", 80)
+		c2 := newTestTCPConn("10.0.0.1", 5000, "10.0.0.3", 80)
+		assert.NoError(t, connMap.insert(c1))
+		assert.NoError(t, connMap.insert(c2))
+
+		assert.NoError(t, connMap.deleteConn(c1))
+
+		// Port slot still exists because c2 is present.
+		assert.Equal(t, 1, len(connMap.portMap))
+
+		// Deleting c1 again must fail.
+		assert.ErrorIs(t, connMap.deleteConn(c1), errNoSuchTCPConn)
+	})
+
+	t.Run("insert a TCPConn on 0.0.0.0 and find it by specified IP", func(t *testing.T) {
+		connMap := newTCPConnMap()
+
+		c1 := newTestTCPConn("0.0.0.0", 1234, "10.0.0.2", 5678)
+		err := connMap.insert(c1)
+		assert.NoError(t, err, "should succeed")
+
+		out, ok := findTCPConnByTuple(connMap, "192.168.0.1", 1234, "10.0.0.2", 5678)
+		assert.True(t, ok, "should succeed")
+		assert.Equal(t, c1, out, "should match")
+	})
+
+	t.Run("insert many remote tuples with the same local port", func(t *testing.T) {
+		connMap := newTCPConnMap()
+
+		c1 := newTestTCPConn("10.1.2.1", 5678, "10.1.2.100", 1111)
+		err := connMap.insert(c1)
+		assert.NoError(t, err, "should succeed")
+
+		c2 := newTestTCPConn("10.1.2.1", 5678, "10.1.2.101", 2222)
+		err = connMap.insert(c2)
+		assert.NoError(t, err, "should succeed")
+
+		out1, ok := findTCPConnByTuple(connMap, "10.1.2.1", 5678, "10.1.2.100", 1111)
+		assert.True(t, ok, "should succeed")
+		assert.Equal(t, c1, out1, "should match")
+
+		out2, ok := findTCPConnByTuple(connMap, "10.1.2.1", 5678, "10.1.2.101", 2222)
+		assert.True(t, ok, "should succeed")
+		assert.Equal(t, c2, out2, "should match")
+
+		assert.Equal(t, 1, len(connMap.portMap), "should match")
+	})
+
+	t.Run("already in-use when inserting the same tuple", func(t *testing.T) {
+		connMap := newTCPConnMap()
+
+		c1 := newTestTCPConn("192.168.0.1", 5678, "192.168.0.2", 9999)
+		err := connMap.insert(c1)
+		assert.NoError(t, err, "should succeed")
+
+		c2 := newTestTCPConn("192.168.0.1", 5678, "192.168.0.2", 9999)
+		err = connMap.insert(c2)
+		assert.Error(t, err, "should fail")
+	})
+
+	t.Run("already in-use when inserting specific-IP conn after wildcard conn (same remote)", func(t *testing.T) {
+		// A 0.0.0.0-local conn matches any destination IP in findByChunk, so a
+		// specific-IP conn with the same local port + remote tuple must be rejected.
+		connMap := newTCPConnMap()
+
+		c1 := newTestTCPConn("0.0.0.0", 5678, "10.0.0.2", 9999)
+		assert.NoError(t, connMap.insert(c1))
+
+		c2 := newTestTCPConn("192.168.0.1", 5678, "10.0.0.2", 9999)
+		assert.ErrorIs(t, connMap.insert(c2), errTCPConnAlreadyUsed)
+	})
+
+	t.Run("already in-use when inserting wildcard conn after specific-IP conn (same remote)", func(t *testing.T) {
+		// Symmetrically, a wildcard conn must be rejected when a specific-IP conn
+		// already occupies the same local port + remote tuple.
+		connMap := newTCPConnMap()
+
+		c1 := newTestTCPConn("192.168.0.1", 5678, "10.0.0.2", 9999)
+		assert.NoError(t, connMap.insert(c1))
+
+		c2 := newTestTCPConn("0.0.0.0", 5678, "10.0.0.2", 9999)
+		assert.ErrorIs(t, connMap.insert(c2), errTCPConnAlreadyUsed)
+	})
+
+	t.Run("different remote tuple is still allowed after wildcard conn", func(t *testing.T) {
+		// A wildcard local conn must not block connections to a different remote.
+		connMap := newTCPConnMap()
+
+		c1 := newTestTCPConn("0.0.0.0", 5678, "10.0.0.2", 9999)
+		assert.NoError(t, connMap.insert(c1))
+
+		c2 := newTestTCPConn("192.168.0.1", 5678, "10.0.0.3", 9999)
+		assert.NoError(t, connMap.insert(c2))
+	})
+
+	t.Run("find failure 1 (remote mismatch)", func(t *testing.T) {
+		connMap := newTCPConnMap()
+
+		c1 := newTestTCPConn("192.168.0.1", 5678, "192.168.0.2", 9999)
+		err := connMap.insert(c1)
+		assert.NoError(t, err, "should succeed")
+
+		_, ok := findTCPConnByTuple(connMap, "192.168.0.1", 5678, "192.168.0.3", 9999)
+		assert.False(t, ok, "should fail")
+	})
+
+	t.Run("find failure 2 (port mismatch)", func(t *testing.T) {
+		connMap := newTCPConnMap()
+
+		c1 := newTestTCPConn("192.168.0.1", 5678, "192.168.0.2", 9999)
+		err := connMap.insert(c1)
+		assert.NoError(t, err, "should succeed")
+
+		_, ok := findTCPConnByTuple(connMap, "192.168.0.1", 1234, "192.168.0.2", 9999)
+		assert.False(t, ok, "should fail")
+	})
+
+	// deleteByAddr must use all 4 tuple values so that two connections sharing the same local addr
+	// but different remote addrs are each deleted independently.
+	t.Run("deleteByAddr removes only the matching 4-tuple", func(t *testing.T) {
+		connMap := newTCPConnMap()
+
+		// Two connections from the same local addr to different remote hosts.
+		c1 := newTestTCPConn("10.0.0.1", 5000, "10.0.0.2", 80)
+		c2 := newTestTCPConn("10.0.0.1", 5000, "10.0.0.3", 80)
+
+		assert.NoError(t, connMap.insert(c1))
+		assert.NoError(t, connMap.insert(c2))
+
+		laddr := &net.TCPAddr{IP: net.ParseIP("10.0.0.1"), Port: 5000}
+		raddr := &net.TCPAddr{IP: net.ParseIP("10.0.0.2"), Port: 80}
+		assert.NoError(t, connMap.deleteByAddr(laddr, raddr))
+
+		// c1 must be gone.
+		_, ok1 := findTCPConnByTuple(connMap, "10.0.0.1", 5000, "10.0.0.2", 80)
+		assert.False(t, ok1, "c1 should be removed")
+
+		// c2 must survive — a laddr-only match would have removed it too.
+		out2, ok2 := findTCPConnByTuple(connMap, "10.0.0.1", 5000, "10.0.0.3", 80)
+		assert.True(t, ok2, "c2 should remain")
+		assert.Equal(t, c2, out2, "should match")
+
+		// Trying to delete c1 again must fail.
+		assert.Error(t, connMap.deleteByAddr(laddr, raddr), "should fail — already removed")
+	})
+
+	t.Run("portInUse returns false when map is empty", func(t *testing.T) {
+		connMap := newTCPConnMap()
+
+		assert.False(t, connMap.portInUse(net.ParseIP("10.0.0.1"), 5000))
+	})
+
+	t.Run("portInUse returns true for exact IP match", func(t *testing.T) {
+		connMap := newTCPConnMap()
+
+		c1 := newTestTCPConn("10.0.0.1", 5000, "10.0.0.2", 80)
+		assert.NoError(t, connMap.insert(c1))
+
+		assert.True(t, connMap.portInUse(net.ParseIP("10.0.0.1"), 5000))
+	})
+
+	t.Run("portInUse returns false when port matches but IP does not", func(t *testing.T) {
+		connMap := newTCPConnMap()
+
+		c1 := newTestTCPConn("10.0.0.1", 5000, "10.0.0.2", 80)
+		assert.NoError(t, connMap.insert(c1))
+
+		assert.False(t, connMap.portInUse(net.ParseIP("10.0.0.9"), 5000))
+	})
+
+	t.Run("portInUse returns false when port does not match", func(t *testing.T) {
+		connMap := newTCPConnMap()
+
+		c1 := newTestTCPConn("10.0.0.1", 5000, "10.0.0.2", 80)
+		assert.NoError(t, connMap.insert(c1))
+
+		assert.False(t, connMap.portInUse(net.ParseIP("10.0.0.1"), 9999))
+	})
+
+	t.Run("portInUse returns true when local addr is unspecified (0.0.0.0)", func(t *testing.T) {
+		connMap := newTCPConnMap()
+
+		c1 := newTestTCPConn("0.0.0.0", 5000, "10.0.0.2", 80)
+		assert.NoError(t, connMap.insert(c1))
+
+		// Any IP on that port should match an unspecified local address.
+		assert.True(t, connMap.portInUse(net.ParseIP("192.168.1.1"), 5000))
+	})
+
+	t.Run("portInUse returns true when one of many conns on port matches", func(t *testing.T) {
+		connMap := newTCPConnMap()
+
+		c1 := newTestTCPConn("10.0.0.1", 5000, "10.0.0.2", 80)
+		c2 := newTestTCPConn("10.0.0.1", 5000, "10.0.0.3", 81)
+		assert.NoError(t, connMap.insert(c1))
+		assert.NoError(t, connMap.insert(c2))
+
+		assert.True(t, connMap.portInUse(net.ParseIP("10.0.0.1"), 5000))
+		assert.False(t, connMap.portInUse(net.ParseIP("10.0.0.9"), 5000))
+	})
+}


### PR DESCRIPTION
New data structures for managing TCP state inside `vnet`, plus the minimal type stubs they depend on.

- `TCPConn`: bare-minimum struct implementing `transport.TCPConn`; holds `locAddr`/`remAddr` and exposes `LocalAddr()`/`RemoteAddr()`. All other methods return `transport.ErrNotSupported`.
- `TCPListener`: bare-minimum struct implementing `transport.TCPListener`; holds `locAddr` and exposes `Addr()`. All other methods return `transport.ErrNotSupported`.
- `tcpConnMap`: thread-safe map of active TCP connections keyed by 4-tuple, with `insert`, `findByChunk`, `deleteConn`, `deleteByAddr`, and `portInUse` helpers.
- `tcpListenerMap`: thread-safe map of TCP listeners keyed by local address, with `insert`, `find`, and `delete` helpers.
- Full unit tests for both maps.


Split out from https://github.com/pion/transport/pull/375