### PR TITLE
Implement TCP connection (tcpConn)

### DIFF
--- a/vnet/conn.go
+++ b/vnet/conn.go
@@ -181,7 +181,7 @@ loop:
 				Op:   "read",
 				Net:  c.locAddr.Network(),
 				Addr: c.locAddr,
-				Err:  newTimeoutError("i/o timeout"),
+				Err:  errIOTimeout,
 			}
 		}
 	}

--- a/vnet/errors.go
+++ b/vnet/errors.go
@@ -7,11 +7,7 @@ type timeoutError struct {
 	msg string
 }
 
-func newTimeoutError(msg string) error {
-	return &timeoutError{
-		msg: msg,
-	}
-}
+var errIOTimeout = &timeoutError{msg: "i/o timeout"} //nolint:gochecknoglobals
 
 func (e *timeoutError) Error() string {
 	return e.msg

--- a/vnet/tcp_conn.go
+++ b/vnet/tcp_conn.go
@@ -4,44 +4,491 @@
 package vnet
 
 import (
+	"errors"
 	"io"
 	"net"
+	"sync"
 	"time"
 
+	"github.com/pion/logging"
 	"github.com/pion/transport/v4"
+)
+
+type tcpState uint8
+
+const (
+	tcpStateInit tcpState = iota
+	tcpStateSynSent
+	tcpStateSynReceived
+	tcpStateEstablished
+	tcpStateClosed
+)
+
+var (
+	errConnectionReset          = errors.New("connection reset")
+	errConnectionNotEstablished = errors.New("connection not established")
 )
 
 // TCPConn implements transport.TCPConn.
 type TCPConn struct {
 	locAddr *net.TCPAddr
 	remAddr *net.TCPAddr
+	obs     connObserver
+
+	mu            sync.Mutex
+	state         tcpState
+	inboundCh     chan tcpSegment
+	curSeg        *tcpSegment
+	curSegOffset  int
+	readClosed    bool // read side closed (remote FIN/RST or local CloseRead/Close)
+	readChClosed  bool
+	writeClosed   bool
+	closed        bool
+	readDeadline  time.Time
+	writeDeadline time.Time
+
+	nextSeq     uint32
+	pendingAcks map[uint32]chan struct{}
+
+	// client connect flow
+	establishedCh chan struct{}
+	establishErr  error
+
+	// server side: notify listener once established
+	onEstablished func(*TCPConn)
+
+	log logging.LeveledLogger
 }
+
+type tcpSegment struct {
+	seq  uint32
+	data []byte
+}
+
+// tcpConnCloseAddr carries both endpoints of a TCP connection. It is passed to
+// connObserver.onClosed so that the observer can perform full 4-tuple matching
+// when removing the connection from the map, rather than laddr-only matching.
+type tcpConnCloseAddr struct {
+	laddr *net.TCPAddr
+	raddr *net.TCPAddr
+}
+
+func (a *tcpConnCloseAddr) Network() string { return tcp }
+func (a *tcpConnCloseAddr) String() string  { return a.laddr.String() + "->" + a.raddr.String() }
+
+// tcpInboundQueueSize is the depth of the per-connection inbound segment channel.
+// vnet has no retransmission, so a dropped segment means permanent data loss for
+// that connection. 64 slots give burst-heavy tests and the duplication filter
+// enough headroom without consuming significant memory.
+const tcpInboundQueueSize = 64
 
 var _ transport.TCPConn = &TCPConn{}
 
+// nolint:unparam
+func newTCPConn(
+	locAddr, remAddr *net.TCPAddr, obs connObserver, log logging.LeveledLogger, onEstablished func(*TCPConn),
+) (*TCPConn, error) {
+	if obs == nil {
+		return nil, errObsCannotBeNil
+	}
+	if log == nil {
+		log = logging.NewDefaultLoggerFactory().NewLogger("vnet")
+	}
+
+	conn := &TCPConn{
+		locAddr:       locAddr,
+		remAddr:       remAddr,
+		obs:           obs,
+		log:           log,
+		state:         tcpStateInit,
+		inboundCh:     make(chan tcpSegment, tcpInboundQueueSize),
+		establishedCh: make(chan struct{}),
+		onEstablished: onEstablished,
+		pendingAcks:   map[uint32]chan struct{}{},
+	}
+
+	return conn, nil
+}
+
+// func (c *TCPConn) startClientHandshake() error {}
+
+// func (c *TCPConn) waitEstablished() error {}
+
+func (c *TCPConn) onInboundChunk(chunk *chunkTCP) { // nolint:cyclop,gocognit
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closed {
+		return
+	}
+
+	// RST aborts connection immediately
+	if chunk.flags&tcpRST != 0 {
+		c.establishErr = &net.OpError{Op: "dial", Net: tcp, Addr: c.remAddr, Err: errConnectionReset}
+		c.closed = true
+		c.state = tcpStateClosed
+		c.readClosed = true
+		c.closeReadChLocked()
+		c.closePendingAcksLocked()
+		select {
+		case <-c.establishedCh:
+		default:
+			close(c.establishedCh)
+		}
+
+		go c.obs.onClosed(&tcpConnCloseAddr{laddr: c.locAddr, raddr: c.remAddr})
+
+		return
+	}
+
+	// handshake
+	if c.state == tcpStateSynSent {
+		if chunk.flags&(tcpSYN|tcpACK) == (tcpSYN | tcpACK) {
+			c.state = tcpStateEstablished
+			// reply ACK
+			src := &net.TCPAddr{IP: c.locAddr.IP, Port: c.locAddr.Port}
+			dst := &net.TCPAddr{IP: c.remAddr.IP, Port: c.remAddr.Port}
+			ack := newChunkTCP(src, dst, tcpACK)
+			go func() { _ = c.obs.write(ack) }()
+			select {
+			case <-c.establishedCh:
+			default:
+				close(c.establishedCh)
+			}
+
+			return
+		}
+	}
+
+	if c.state == tcpStateSynReceived {
+		if chunk.flags&tcpACK != 0 && chunk.flags&tcpSYN == 0 {
+			c.state = tcpStateEstablished
+			cb := c.onEstablished
+			if cb != nil {
+				go cb(c)
+			}
+			// Do not return here; the first ACK may also carry data (PSH).
+		}
+	}
+
+	if chunk.flags&tcpFIN != 0 {
+		c.readClosed = true
+		select {
+		case <-c.establishedCh:
+		default:
+			// if the other side closed before connect completed
+			c.establishErr = io.EOF
+			close(c.establishedCh)
+		}
+		c.closeReadChLocked()
+
+		return
+	}
+
+	// Data ACK
+	// nextSeq is always incremented as nextSeq+1 before use, so assigned
+	// sequence numbers are always ≥ 1. The ackNum != 0 guard therefore never
+	// excludes a legitimate ACK in practice (seq 0 is never issued). After a
+	// uint32 wrap this would incorrectly skip an ACK for seq 0, but that
+	// requires ~4 billion writes and is unreachable in any real test workload.
+	if chunk.flags&tcpACK != 0 && chunk.ackNum != 0 {
+		if ch, ok := c.pendingAcks[chunk.ackNum]; ok {
+			delete(c.pendingAcks, chunk.ackNum)
+			close(ch)
+		}
+		// ACK may accompany other flags (e.g. PSH), so don't return.
+	}
+
+	if chunk.flags&tcpPSH != 0 && len(chunk.userData) > 0 {
+		payload := make([]byte, len(chunk.userData))
+		copy(payload, chunk.userData)
+		if !c.readChClosed {
+			seg := tcpSegment{seq: chunk.seqNum, data: payload}
+			select {
+			case c.inboundCh <- seg:
+			default:
+				// Receive queue is full — drop the segment and log so that data loss
+				// is observable during debugging.
+				c.log.Debugf("tcp: %s->%s: inbound segment seq=%d dropped (receive queue full)",
+					c.remAddr, c.locAddr, chunk.seqNum)
+			}
+		}
+
+		return
+	}
+}
+
+func (c *TCPConn) closeReadChLocked() {
+	if c.readChClosed {
+		return
+	}
+	c.readChClosed = true
+	close(c.inboundCh)
+}
+
+func (c *TCPConn) closePendingAcksLocked() {
+	for _, ch := range c.pendingAcks {
+		close(ch)
+	}
+	clear(c.pendingAcks)
+}
+
 // Read reads data from the connection.
-func (c *TCPConn) Read(b []byte) (int, error) {
-	return 0, transport.ErrNotSupported
+func (c *TCPConn) Read(b []byte) (int, error) { // nolint:gocognit,cyclop
+	if len(b) == 0 {
+		return 0, nil
+	}
+	for {
+		var ack *chunkTCP
+		c.mu.Lock()
+		if c.closed {
+			c.mu.Unlock()
+
+			return 0, &net.OpError{Op: "read", Net: tcp, Addr: c.locAddr, Err: errUseClosedNetworkConn}
+		}
+		// Serve current segment if present.
+		if c.curSeg != nil {
+			remaining := c.curSeg.data[c.curSegOffset:]
+			n := copy(b, remaining)
+			c.curSegOffset += n
+			if c.curSegOffset >= len(c.curSeg.data) {
+				// ACK after the segment has been read.
+				src := &net.TCPAddr{IP: c.locAddr.IP, Port: c.locAddr.Port}
+				dst := &net.TCPAddr{IP: c.remAddr.IP, Port: c.remAddr.Port}
+				ack = newChunkTCP(src, dst, tcpACK)
+				ack.ackNum = c.curSeg.seq
+				c.curSeg = nil
+				c.curSegOffset = 0
+			}
+			c.mu.Unlock()
+			if ack != nil {
+				_ = c.obs.write(ack)
+			}
+
+			return n, nil
+		}
+
+		inboundCh := c.inboundCh
+		deadline := c.readDeadline
+		c.mu.Unlock()
+
+		// Wait for the next segment.
+		if !deadline.IsZero() { // nolint:nestif
+			until := time.Until(deadline)
+			if until <= 0 {
+				return 0, &net.OpError{Op: "read", Net: tcp, Addr: c.locAddr, Err: errIOTimeout}
+			}
+			timer := time.NewTimer(until)
+			select {
+			case seg, ok := <-inboundCh:
+				if !timer.Stop() {
+					<-timer.C
+				}
+				if !ok {
+					c.mu.Lock()
+					defer c.mu.Unlock()
+					if c.closed {
+						return 0, &net.OpError{Op: "read", Net: tcp, Addr: c.locAddr, Err: errUseClosedNetworkConn}
+					}
+
+					return 0, io.EOF
+				}
+				c.mu.Lock()
+				c.curSeg = &seg
+				c.curSegOffset = 0
+				c.mu.Unlock()
+
+				continue
+			case <-timer.C:
+				return 0, &net.OpError{Op: "read", Net: tcp, Addr: c.locAddr, Err: errIOTimeout}
+			}
+		}
+
+		seg, ok := <-inboundCh
+		if !ok {
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			if c.closed {
+				return 0, &net.OpError{Op: "read", Net: tcp, Addr: c.locAddr, Err: errUseClosedNetworkConn}
+			}
+
+			return 0, io.EOF
+		}
+		c.mu.Lock()
+		c.curSeg = &seg
+		c.curSegOffset = 0
+		c.mu.Unlock()
+	}
 }
 
 // Write writes data to the connection.
-func (c *TCPConn) Write(b []byte) (int, error) {
-	return 0, transport.ErrNotSupported
+func (c *TCPConn) Write(b []byte) (int, error) { // nolint:cyclop
+	if len(b) == 0 {
+		return 0, nil
+	}
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+
+		return 0, &net.OpError{Op: "write", Net: tcp, Addr: c.locAddr, Err: errUseClosedNetworkConn}
+	}
+	if c.writeClosed {
+		c.mu.Unlock()
+
+		return 0, io.ErrClosedPipe
+	}
+	if c.state != tcpStateEstablished {
+		c.mu.Unlock()
+
+		return 0, errConnectionNotEstablished
+	}
+
+	seq := c.nextSeq + 1
+	c.nextSeq = seq
+	ackCh := make(chan struct{})
+	c.pendingAcks[seq] = ackCh
+	deadline := c.writeDeadline
+
+	payload := make([]byte, len(b))
+	copy(payload, b)
+	src := &net.TCPAddr{IP: c.locAddr.IP, Port: c.locAddr.Port}
+	dst := &net.TCPAddr{IP: c.remAddr.IP, Port: c.remAddr.Port}
+	chunk := newChunkTCP(src, dst, tcpPSH|tcpACK)
+	chunk.userData = payload
+	chunk.seqNum = seq
+	c.mu.Unlock()
+
+	if err := c.obs.write(chunk); err != nil {
+		// obs.write failed — the chunk was never sent, so no ACK will arrive.
+		// Re-acquire c.mu and remove the pending entry before closing the channel
+		// to unblock any concurrent waiter. The ok-check guards against a
+		// concurrent closePendingAcksLocked() having already removed the entry;
+		// all accesses to pendingAcks are serialized through c.mu so no
+		// double-close is possible.
+		c.mu.Lock()
+		if ch, ok := c.pendingAcks[seq]; ok {
+			delete(c.pendingAcks, seq)
+			close(ch)
+		}
+		c.mu.Unlock()
+
+		return 0, err
+	}
+
+	if !deadline.IsZero() {
+		until := time.Until(deadline)
+		if until <= 0 {
+			return 0, &net.OpError{Op: "write", Net: tcp, Addr: c.locAddr, Err: errIOTimeout}
+		}
+		timer := time.NewTimer(until)
+		select {
+		case <-ackCh:
+			if !timer.Stop() {
+				<-timer.C
+			}
+			c.mu.Lock()
+			closed := c.closed
+			c.mu.Unlock()
+			if closed {
+				return 0, &net.OpError{Op: "write", Net: tcp, Addr: c.locAddr, Err: errUseClosedNetworkConn}
+			}
+
+			return len(b), nil
+		case <-timer.C:
+			c.mu.Lock()
+			if ch, ok := c.pendingAcks[seq]; ok {
+				delete(c.pendingAcks, seq)
+				close(ch)
+			}
+			c.mu.Unlock()
+
+			return 0, &net.OpError{Op: "write", Net: tcp, Addr: c.locAddr, Err: errIOTimeout}
+		}
+	}
+
+	<-ackCh
+	c.mu.Lock()
+	closed := c.closed
+	c.mu.Unlock()
+	if closed {
+		return 0, &net.OpError{Op: "write", Net: tcp, Addr: c.locAddr, Err: errUseClosedNetworkConn}
+	}
+
+	return len(b), nil
 }
 
 // Close closes the connection.
 func (c *TCPConn) Close() error {
-	return transport.ErrNotSupported
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+
+		return errAlreadyClosed
+	}
+	c.closed = true
+	c.state = tcpStateClosed
+	c.readClosed = true
+	// Capture writeClosed before setting it so we know whether to send the FIN.
+	// We cannot call CloseWrite() after this point because CloseWrite() guards on
+	// c.closed (which is now true) and would return immediately without sending
+	// the FIN segment.
+	alreadyWriteClosed := c.writeClosed
+	c.writeClosed = true
+	src := &net.TCPAddr{IP: c.locAddr.IP, Port: c.locAddr.Port}
+	dst := &net.TCPAddr{IP: c.remAddr.IP, Port: c.remAddr.Port}
+	c.closeReadChLocked()
+	c.closePendingAcksLocked()
+	c.mu.Unlock()
+
+	// Send FIN so the remote peer's Read returns io.EOF.
+	if !alreadyWriteClosed {
+		fin := newChunkTCP(src, dst, tcpFIN|tcpACK)
+		_ = c.obs.write(fin)
+	}
+	c.obs.onClosed(&tcpConnCloseAddr{laddr: c.locAddr, raddr: c.remAddr})
+
+	return nil
 }
 
 // CloseRead closes the read side of the connection.
+// NOTE: closing inboundCh does not discard elements already buffered in it,
+// so a subsequent Read() may still return queued segments before returning
+// io.EOF. This differs from a strict read-side shutdown, but is acceptable
+// here because vnet is a test-only simulator rather than a production
+// network stack.
 func (c *TCPConn) CloseRead() error {
-	return transport.ErrNotSupported
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.readClosed = true
+	c.closeReadChLocked()
+
+	return nil
 }
 
 // CloseWrite closes the write side of the connection.
 func (c *TCPConn) CloseWrite() error {
-	return transport.ErrNotSupported
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+
+		return errUseClosedNetworkConn
+	}
+	if c.writeClosed {
+		c.mu.Unlock()
+
+		return nil
+	}
+	c.writeClosed = true
+	src := &net.TCPAddr{IP: c.locAddr.IP, Port: c.locAddr.Port}
+	dst := &net.TCPAddr{IP: c.remAddr.IP, Port: c.remAddr.Port}
+	fin := newChunkTCP(src, dst, tcpFIN|tcpACK)
+	c.mu.Unlock()
+
+	// writeClosed is already true at this point. If write(fin) fails, we do not
+	// roll it back: a subsequent CloseWrite() call would return nil (no-op) and
+	// the FIN would be permanently lost. For a vnet simulator this is acceptable
+	// — write() failures are rare and the connection is effectively broken anyway.
+	return c.obs.write(fin)
 }
 
 // LocalAddr returns the local network address.
@@ -56,22 +503,54 @@ func (c *TCPConn) RemoteAddr() net.Addr {
 
 // SetDeadline sets the read and write deadlines associated with the connection.
 func (c *TCPConn) SetDeadline(t time.Time) error {
-	return transport.ErrNotSupported
+	if err := c.SetReadDeadline(t); err != nil {
+		return err
+	}
+
+	return c.SetWriteDeadline(t)
 }
 
 // SetReadDeadline sets the deadline for future Read calls.
 func (c *TCPConn) SetReadDeadline(t time.Time) error {
-	return transport.ErrNotSupported
+	c.mu.Lock()
+	c.readDeadline = t
+	c.mu.Unlock()
+
+	return nil
 }
 
 // SetWriteDeadline sets the deadline for future Write calls.
 func (c *TCPConn) SetWriteDeadline(t time.Time) error {
-	return transport.ErrNotSupported
+	c.mu.Lock()
+	c.writeDeadline = t
+	c.mu.Unlock()
+
+	return nil
 }
 
 // ReadFrom reads data from r and writes it to the connection.
+// It implements the copy loop directly instead of calling io.Copy(c, r) to
+// avoid infinite recursion: io.Copy detects that c satisfies io.ReaderFrom and
+// would call c.ReadFrom again.
 func (c *TCPConn) ReadFrom(r io.Reader) (int64, error) {
-	return 0, transport.ErrNotSupported
+	buf := make([]byte, 32*1024)
+	var total int64
+	for {
+		nr, er := r.Read(buf)
+		if nr > 0 {
+			nw, ew := c.Write(buf[:nr])
+			total += int64(nw)
+			if ew != nil {
+				return total, ew
+			}
+		}
+		if er == io.EOF {
+			return total, nil
+		}
+		if er != nil {
+			return total, er
+		}
+	}
 }
 
 // SetLinger sets the behavior of Close method on a connection with pending data.

--- a/vnet/tcp_conn_test.go
+++ b/vnet/tcp_conn_test.go
@@ -1,0 +1,732 @@
+// SPDX-FileCopyrightText: 2026 The Pion community <https://pion.ly>
+// SPDX-License-Identifier: MIT
+
+package vnet
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pion/logging"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errFailedToConvertToChunkTCP = errors.New("failed to convert chunk to chunkTCP")
+
+// tcpTestLogger is a shared logger used by newTCPConn calls in unit tests.
+var tcpTestLogger = logging.NewDefaultLoggerFactory().NewLogger("test") //nolint:gochecknoglobals
+
+func newAckingEchoTCPObserver(connPtr **TCPConn) *dummyObserver {
+	return &dummyObserver{
+		onWrite: func(c Chunk) error {
+			conn := *connPtr
+			if conn == nil {
+				return errors.New("tcp conn is nil") // nolint:err113
+			}
+
+			tc, ok := c.(*chunkTCP)
+			if !ok {
+				return errFailedToConvertToChunkTCP
+			}
+
+			// Immediately ACK the sent segment as if the remote read it.
+			if tc.flags&tcpPSH != 0 && tc.seqNum != 0 {
+				dstAddr := tc.DestinationAddr().(*net.TCPAddr) //nolint:forcetypeassert
+				srcAddr := tc.SourceAddr().(*net.TCPAddr)      //nolint:forcetypeassert
+				ack := newChunkTCP(dstAddr, srcAddr, tcpACK)
+				ack.ackNum = tc.seqNum
+				conn.onInboundChunk(ack)
+			}
+
+			// Echo back payload as if it came from the remote.
+			dstAddr := tc.DestinationAddr().(*net.TCPAddr) //nolint:forcetypeassert
+			srcAddr := tc.SourceAddr().(*net.TCPAddr)      //nolint:forcetypeassert
+			echo := newChunkTCP(dstAddr, srcAddr, tcpPSH|tcpACK)
+			echo.userData = make([]byte, len(tc.userData))
+			copy(echo.userData, tc.userData)
+			conn.onInboundChunk(echo)
+
+			return nil
+		},
+		onOnClosed: func(net.Addr) {},
+	}
+}
+
+func TestTCPConn(t *testing.T) { //nolint:cyclop,maintidx,gocyclo
+	log := logging.NewDefaultLoggerFactory().NewLogger("test")
+
+	t.Run("ReadFrom Read", func(t *testing.T) {
+		var conn *TCPConn
+		data := []byte("Hello")
+		srcAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		dstAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678}
+
+		obs := newAckingEchoTCPObserver(&conn)
+
+		var err error
+		conn, err = newTCPConn(srcAddr, dstAddr, obs, tcpTestLogger, nil)
+		assert.NoError(t, err, "should succeed")
+
+		conn.mu.Lock()
+		conn.state = tcpStateEstablished
+		conn.mu.Unlock()
+
+		rcvdCh := make(chan struct{})
+		doneCh := make(chan struct{})
+
+		go func() {
+			buf := make([]byte, 1500)
+
+			for {
+				n, err2 := conn.Read(buf)
+				if err2 != nil {
+					log.Debug("conn closed. exiting the read loop")
+
+					break
+				}
+				log.Debug("read data")
+				assert.Equal(t, len(data), n, "should match")
+				assert.Equal(t, string(data), string(buf[:n]), "should match")
+				rcvdCh <- struct{}{}
+			}
+
+			close(doneCh)
+		}()
+
+		n, err := conn.ReadFrom(bytes.NewReader(data))
+		if !assert.NoError(t, err, "should succeed") {
+			return
+		}
+		assert.Equal(t, int64(len(data)), n, "should match")
+
+	loop:
+		for {
+			select {
+			case <-rcvdCh:
+				log.Debug("closing conn..")
+				err2 := conn.Close()
+				assert.Nil(t, err2, "should succeed")
+			case <-doneCh:
+				break loop
+			}
+		}
+	})
+
+	t.Run("Write Read", func(t *testing.T) {
+		var conn *TCPConn
+		var err error
+		data := []byte("Hello")
+		srcAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		dstAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678}
+
+		obs := newAckingEchoTCPObserver(&conn)
+
+		conn, err = newTCPConn(srcAddr, dstAddr, obs, tcpTestLogger, nil)
+		assert.NoError(t, err, "should succeed")
+
+		conn.mu.Lock()
+		conn.state = tcpStateEstablished
+		conn.mu.Unlock()
+
+		rcvdCh := make(chan struct{})
+		doneCh := make(chan struct{})
+
+		go func() {
+			buf := make([]byte, 1500)
+
+			for {
+				n, err2 := conn.Read(buf)
+				if err2 != nil {
+					log.Debug("conn closed. exiting the read loop")
+
+					break
+				}
+				log.Debug("read data")
+				assert.Equal(t, len(data), n, "should match")
+				assert.Equal(t, string(data), string(buf[:n]), "should match")
+				rcvdCh <- struct{}{}
+			}
+
+			close(doneCh)
+		}()
+
+		var n int
+		n, err = conn.Write(data)
+		if !assert.Nil(t, err, "should succeed") {
+			return
+		}
+		assert.Equal(t, len(data), n, "should match")
+
+	loop:
+		for {
+			select {
+			case <-rcvdCh:
+				log.Debug("closing conn..")
+				err = conn.Close()
+				assert.Nil(t, err, "should succeed")
+			case <-doneCh:
+				break loop
+			}
+		}
+	})
+
+	deadlineTest := func(t *testing.T, readOnly bool) {
+		t.Helper()
+
+		var conn *TCPConn
+		srcAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		dstAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678}
+
+		obs := &dummyObserver{
+			onWrite:    func(Chunk) error { return nil },
+			onOnClosed: func(net.Addr) {},
+		}
+
+		var err error
+		conn, err = newTCPConn(srcAddr, dstAddr, obs, tcpTestLogger, nil)
+		assert.NoError(t, err, "should succeed")
+
+		conn.mu.Lock()
+		conn.state = tcpStateEstablished
+		conn.mu.Unlock()
+
+		doneCh := make(chan struct{})
+
+		if readOnly {
+			err = conn.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+		} else {
+			err = conn.SetDeadline(time.Now().Add(50 * time.Millisecond))
+		}
+		assert.Nil(t, err, "should succeed")
+
+		go func() {
+			buf := make([]byte, 1500)
+			_, err2 := conn.Read(buf)
+			assert.NotNil(t, err2, "should return error")
+			var ne *net.OpError
+			if errors.As(err2, &ne) {
+				assert.True(t, ne.Timeout(), "should be a timeout")
+			} else {
+				assert.True(t, false, "should be an net.OpError")
+			}
+
+			assert.Nil(t, conn.Close(), "should succeed")
+			close(doneCh)
+		}()
+
+		<-doneCh
+	}
+
+	t.Run("SetReadDeadline", func(t *testing.T) {
+		deadlineTest(t, true)
+	})
+
+	t.Run("SetDeadline", func(t *testing.T) {
+		deadlineTest(t, false)
+	})
+
+	t.Run("SetWriteDeadline", func(t *testing.T) {
+		srcAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		dstAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678}
+
+		obs := &dummyObserver{
+			onWrite:    func(Chunk) error { return nil },
+			onOnClosed: func(net.Addr) {},
+		}
+
+		conn, err := newTCPConn(srcAddr, dstAddr, obs, tcpTestLogger, nil)
+		assert.NoError(t, err, "should succeed")
+
+		conn.mu.Lock()
+		conn.state = tcpStateEstablished
+		conn.mu.Unlock()
+
+		err = conn.SetWriteDeadline(time.Now().Add(50 * time.Millisecond))
+		assert.NoError(t, err, "should succeed")
+
+		_, err = conn.Write([]byte("blocked"))
+		assert.Error(t, err, "should timeout")
+		var ne *net.OpError
+		if errors.As(err, &ne) {
+			assert.True(t, ne.Timeout(), "should be a timeout")
+		} else {
+			assert.True(t, false, "should be a net.OpError")
+		}
+
+		assert.NoError(t, conn.Close(), "should succeed")
+	})
+
+	t.Run("Write blocks until peer reads", func(t *testing.T) {
+		msg := []byte("Hello")
+		addrA := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		addrB := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678}
+
+		var connA *TCPConn
+		var connB *TCPConn
+
+		obsA := &dummyObserver{
+			onWrite: func(c Chunk) error {
+				tc, ok := c.(*chunkTCP)
+				if !ok {
+					return errFailedToConvertToChunkTCP
+				}
+				// Deliver to peer.
+				connB.onInboundChunk(tc.Clone().(*chunkTCP)) //nolint:forcetypeassert
+
+				return nil
+			},
+			onOnClosed: func(net.Addr) {},
+		}
+
+		obsB := &dummyObserver{
+			onWrite: func(c Chunk) error {
+				tc, ok := c.(*chunkTCP)
+				if !ok {
+					return errFailedToConvertToChunkTCP
+				}
+				// Deliver to peer.
+				connA.onInboundChunk(tc.Clone().(*chunkTCP)) //nolint:forcetypeassert
+
+				return nil
+			},
+			onOnClosed: func(net.Addr) {},
+		}
+
+		var err error
+		connA, err = newTCPConn(addrA, addrB, obsA, tcpTestLogger, nil)
+		assert.NoError(t, err, "should succeed")
+		connB, err = newTCPConn(addrB, addrA, obsB, tcpTestLogger, nil)
+		assert.NoError(t, err, "should succeed")
+
+		connA.mu.Lock()
+		connA.state = tcpStateEstablished
+		connA.mu.Unlock()
+		connB.mu.Lock()
+		connB.state = tcpStateEstablished
+		connB.mu.Unlock()
+
+		writeDone := make(chan error, 1)
+		go func() {
+			_, err2 := connA.Write(msg)
+			writeDone <- err2
+		}()
+
+		// Should still be blocked (no read => no ACK).
+		select {
+		case err2 := <-writeDone:
+			assert.Fail(t, "Write returned before peer read", "%v", err2)
+
+			return
+		case <-time.After(200 * time.Millisecond):
+		}
+
+		_ = connB.SetReadDeadline(time.Now().Add(2 * time.Second))
+		buf := make([]byte, len(msg))
+		_, err = io.ReadFull(connB, buf)
+		assert.NoError(t, err, "should succeed")
+		assert.Equal(t, msg, buf, "should match")
+
+		select {
+		case err2 := <-writeDone:
+			assert.NoError(t, err2, "should succeed")
+		case <-time.After(2 * time.Second):
+			assert.Fail(t, "Write did not unblock after peer read")
+
+			return
+		}
+
+		assert.NoError(t, connA.Close(), "should succeed")
+		assert.NoError(t, connB.Close(), "should succeed")
+	})
+
+	t.Run("RST", func(t *testing.T) {
+		srcAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		dstAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678}
+
+		obs := &dummyObserver{
+			onWrite:    func(Chunk) error { return nil },
+			onOnClosed: func(net.Addr) {},
+		}
+
+		conn, err := newTCPConn(srcAddr, dstAddr, obs, tcpTestLogger, nil)
+		assert.NoError(t, err, "should succeed")
+
+		conn.mu.Lock()
+		conn.state = tcpStateEstablished
+		conn.mu.Unlock()
+
+		writeDone := make(chan error, 1)
+		go func() {
+			_, err2 := conn.Write([]byte("data"))
+			writeDone <- err2
+		}()
+
+		select {
+		case err2 := <-writeDone:
+			assert.Fail(t, "Write returned before RST", "%v", err2)
+
+			return
+		case <-time.After(100 * time.Millisecond):
+		}
+
+		rst := newChunkTCP(dstAddr, srcAddr, tcpRST)
+		conn.onInboundChunk(rst)
+
+		select {
+		case err2 := <-writeDone:
+			assert.Error(t, err2, "should error")
+			var ne *net.OpError
+			if errors.As(err2, &ne) {
+				assert.Equal(t, "write", ne.Op, "should match")
+				assert.Equal(t, errUseClosedNetworkConn, ne.Err, "should match")
+			} else {
+				assert.True(t, false, "should be a net.OpError")
+			}
+		case <-time.After(2 * time.Second):
+			assert.Fail(t, "Write did not unblock after RST")
+
+			return
+		}
+
+		buf := make([]byte, 10)
+		_, err = conn.Read(buf)
+		assert.Error(t, err, "should error")
+		_, err = conn.Write([]byte("x"))
+		assert.Error(t, err, "should error")
+	})
+
+	t.Run("RST calls onClosed with correct addresses", func(t *testing.T) {
+		srcAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		dstAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678}
+
+		closedCh := make(chan net.Addr, 1)
+		obs := &dummyObserver{
+			onWrite:    func(Chunk) error { return nil },
+			onOnClosed: func(addr net.Addr) { closedCh <- addr },
+		}
+
+		conn, err := newTCPConn(srcAddr, dstAddr, obs, tcpTestLogger, nil)
+		require.NoError(t, err)
+
+		conn.mu.Lock()
+		conn.state = tcpStateEstablished
+		conn.mu.Unlock()
+
+		rst := newChunkTCP(dstAddr, srcAddr, tcpRST)
+		conn.onInboundChunk(rst)
+
+		select {
+		case addr := <-closedCh:
+			ca, ok := addr.(*tcpConnCloseAddr)
+			require.True(t, ok, "onClosed should receive *tcpConnCloseAddr")
+			assert.Equal(t, srcAddr, ca.laddr, "laddr should match local address")
+			assert.Equal(t, dstAddr, ca.raddr, "raddr should match remote address")
+		case <-time.After(2 * time.Second):
+			require.Fail(t, "onClosed was not called after RST")
+		}
+	})
+
+	t.Run("ReadClosed (CloseRead)", func(t *testing.T) {
+		srcAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		dstAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678}
+
+		var conn *TCPConn
+		obs := &dummyObserver{
+			onWrite: func(c Chunk) error {
+				tc, ok := c.(*chunkTCP)
+				if !ok {
+					return errFailedToConvertToChunkTCP
+				}
+				// ACK writes so Write doesn't block.
+				if tc.flags&tcpPSH != 0 && tc.seqNum != 0 {
+					dstAddr := tc.DestinationAddr().(*net.TCPAddr) //nolint:forcetypeassert
+					srcAddr := tc.SourceAddr().(*net.TCPAddr)      //nolint:forcetypeassert
+					ack := newChunkTCP(dstAddr, srcAddr, tcpACK)
+					ack.ackNum = tc.seqNum
+					conn.onInboundChunk(ack)
+				}
+
+				return nil
+			},
+			onOnClosed: func(net.Addr) {},
+		}
+
+		var err error
+		conn, err = newTCPConn(srcAddr, dstAddr, obs, tcpTestLogger, nil)
+		assert.NoError(t, err, "should succeed")
+		conn.mu.Lock()
+		conn.state = tcpStateEstablished
+		conn.mu.Unlock()
+
+		assert.NoError(t, conn.CloseRead(), "should succeed")
+
+		buf := make([]byte, 10)
+		_, err = conn.Read(buf)
+		assert.Equal(t, io.EOF, err, "should EOF")
+
+		// Write side still usable until closed.
+		_, err = conn.Write([]byte("ok"))
+		assert.NoError(t, err, "should succeed")
+		assert.NoError(t, conn.Close(), "should succeed")
+	})
+
+	t.Run("ReadClosed (remote FIN)", func(t *testing.T) {
+		srcAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		dstAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678}
+
+		obs := &dummyObserver{
+			onWrite:    func(Chunk) error { return nil },
+			onOnClosed: func(net.Addr) {},
+		}
+
+		conn, err := newTCPConn(srcAddr, dstAddr, obs, tcpTestLogger, nil)
+		assert.NoError(t, err, "should succeed")
+		conn.mu.Lock()
+		conn.state = tcpStateEstablished
+		conn.mu.Unlock()
+
+		fin := newChunkTCP(dstAddr, srcAddr, tcpFIN|tcpACK)
+		conn.onInboundChunk(fin)
+
+		buf := make([]byte, 10)
+		_, err = conn.Read(buf)
+		assert.Equal(t, io.EOF, err, "should EOF")
+		assert.NoError(t, conn.Close(), "should succeed")
+	})
+
+	t.Run("WriteClosed (CloseWrite)", func(t *testing.T) {
+		srcAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		dstAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678}
+
+		obs := &dummyObserver{
+			onWrite:    func(Chunk) error { return nil },
+			onOnClosed: func(net.Addr) {},
+		}
+
+		conn, err := newTCPConn(srcAddr, dstAddr, obs, tcpTestLogger, nil)
+		assert.NoError(t, err, "should succeed")
+		conn.mu.Lock()
+		conn.state = tcpStateEstablished
+		conn.mu.Unlock()
+
+		assert.NoError(t, conn.CloseWrite(), "should succeed")
+		_, err = conn.Write([]byte("nope"))
+		assert.Equal(t, io.ErrClosedPipe, err, "should match")
+		assert.NoError(t, conn.Close(), "should succeed")
+	})
+
+	t.Run("Inbound during close", func(t *testing.T) {
+		var nClosed int32
+		var conn *TCPConn
+		srcAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		dstAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678}
+
+		obs := &dummyObserver{
+			onWrite: func(Chunk) error { return nil },
+			onOnClosed: func(net.Addr) {
+				atomic.AddInt32(&nClosed, 1)
+			},
+		}
+
+		var err error
+		conn, err = newTCPConn(srcAddr, dstAddr, obs, tcpTestLogger, nil)
+		assert.NoError(t, err, "should succeed")
+
+		conn.mu.Lock()
+		conn.state = tcpStateEstablished
+		conn.mu.Unlock()
+
+		fin := newChunkTCP(dstAddr, srcAddr, tcpFIN|tcpACK)
+		psh := newChunkTCP(dstAddr, srcAddr, tcpPSH|tcpACK)
+		psh.userData = []byte("x")
+
+		for range 1000 { // nolint:staticcheck // (false positive detection)
+			chDone := make(chan struct{})
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				assert.NoError(t, conn.Close())
+				close(chDone)
+			}()
+			tick := time.NewTicker(10 * time.Millisecond)
+			defer tick.Stop()
+			for {
+				select {
+				case <-chDone:
+					assert.Equal(t, int32(1), atomic.LoadInt32(&nClosed), "should invoke onClosed exactly once")
+
+					return
+				case <-tick.C:
+					conn.onInboundChunk(psh)
+					conn.onInboundChunk(fin)
+				}
+			}
+		}
+	})
+
+	t.Run("ReadFrom does not recurse infinitely", func(t *testing.T) {
+		var conn *TCPConn
+		srcAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		dstAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678}
+
+		// ACK every PSH immediately so Write unblocks; do not echo data back.
+		obs := &dummyObserver{
+			onWrite: func(c Chunk) error {
+				tc, ok := c.(*chunkTCP)
+				if !ok {
+					return nil
+				}
+				if tc.flags&tcpPSH != 0 && tc.seqNum != 0 {
+					srcAddr := tc.SourceAddr().(*net.TCPAddr)      //nolint:forcetypeassert
+					dstAddr := tc.DestinationAddr().(*net.TCPAddr) //nolint:forcetypeassert
+					ack := newChunkTCP(dstAddr, srcAddr, tcpACK)
+					ack.ackNum = tc.seqNum
+					conn.onInboundChunk(ack)
+				}
+
+				return nil
+			},
+			onOnClosed: func(net.Addr) {},
+		}
+
+		var err error
+		conn, err = newTCPConn(srcAddr, dstAddr, obs, tcpTestLogger, nil)
+		require.NoError(t, err)
+		conn.mu.Lock()
+		conn.state = tcpStateEstablished
+		conn.mu.Unlock()
+
+		data := []byte("hello")
+		done := make(chan struct{})
+		go func() {
+			n, err2 := conn.ReadFrom(bytes.NewReader(data))
+			assert.NoError(t, err2)
+			assert.Equal(t, int64(len(data)), n)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			require.Fail(t, "ReadFrom did not complete — possible infinite recursion")
+		}
+		_ = conn.Close()
+	})
+
+	t.Run("Write zero-length returns immediately", func(t *testing.T) {
+		srcAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		dstAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678}
+
+		obs := &dummyObserver{
+			onWrite:    func(Chunk) error { return nil },
+			onOnClosed: func(net.Addr) {},
+		}
+
+		conn, err := newTCPConn(srcAddr, dstAddr, obs, tcpTestLogger, nil)
+		require.NoError(t, err)
+		conn.mu.Lock()
+		conn.state = tcpStateEstablished
+		conn.mu.Unlock()
+
+		n, err := conn.Write([]byte{})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, n)
+		assert.NoError(t, conn.Close())
+	})
+
+	t.Run("Read zero-length returns immediately", func(t *testing.T) {
+		srcAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		dstAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678}
+
+		obs := &dummyObserver{
+			onWrite:    func(Chunk) error { return nil },
+			onOnClosed: func(net.Addr) {},
+		}
+
+		conn, err := newTCPConn(srcAddr, dstAddr, obs, tcpTestLogger, nil)
+		require.NoError(t, err)
+		conn.mu.Lock()
+		conn.state = tcpStateEstablished
+		conn.mu.Unlock()
+
+		n, err := conn.Read([]byte{})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, n)
+		assert.NoError(t, conn.Close())
+	})
+
+	// Close() must send a FIN so the remote peer's Read returns io.EOF rather than blocking forever.
+	t.Run("Close sends FIN to peer", func(t *testing.T) {
+		addrA := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1234}
+		addrB := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5678}
+
+		var connA *TCPConn
+		var connB *TCPConn
+
+		// obsA forwards outbound chunks from connA directly into connB.
+		obsA := &dummyObserver{
+			onWrite: func(c Chunk) error {
+				tc, ok := c.(*chunkTCP)
+				if !ok {
+					return errFailedToConvertToChunkTCP
+				}
+				connB.onInboundChunk(tc.Clone().(*chunkTCP)) //nolint:forcetypeassert
+
+				return nil
+			},
+			onOnClosed: func(net.Addr) {},
+		}
+
+		// obsB forwards outbound chunks from connB directly into connA.
+		obsB := &dummyObserver{
+			onWrite: func(c Chunk) error {
+				tc, ok := c.(*chunkTCP)
+				if !ok {
+					return errFailedToConvertToChunkTCP
+				}
+				connA.onInboundChunk(tc.Clone().(*chunkTCP)) //nolint:forcetypeassert
+
+				return nil
+			},
+			onOnClosed: func(net.Addr) {},
+		}
+
+		var err error
+		connA, err = newTCPConn(addrA, addrB, obsA, tcpTestLogger, nil)
+		require.NoError(t, err)
+		connB, err = newTCPConn(addrB, addrA, obsB, tcpTestLogger, nil)
+		require.NoError(t, err)
+
+		connA.mu.Lock()
+		connA.state = tcpStateEstablished
+		connA.mu.Unlock()
+		connB.mu.Lock()
+		connB.state = tcpStateEstablished
+		connB.mu.Unlock()
+
+		// Close connA — this must deliver a FIN to connB.
+		require.NoError(t, connA.Close())
+
+		// connB must observe the FIN as io.EOF on Read, not block forever.
+		readDone := make(chan error, 1)
+		go func() {
+			buf := make([]byte, 1)
+			_, err2 := connB.Read(buf)
+			readDone <- err2
+		}()
+
+		select {
+		case err2 := <-readDone:
+			assert.Equal(t, io.EOF, err2, "peer Read should return io.EOF after Close")
+		case <-time.After(2 * time.Second):
+			assert.Fail(t, "peer Read blocked forever — FIN was not delivered by Close")
+		}
+
+		assert.NoError(t, connB.Close())
+	})
+}


### PR DESCRIPTION
Add `tcpConn` type that implements `transport.TCPConn` / `net.Conn`.

- `Read` / `Write` with in-order delivery using `seqNum`/`ackNum`.
- `Close` with FIN/RST handling.
- `SetDeadline`, `SetReadDeadline`, `SetWriteDeadline`.
- Full unit tests covering connection lifecycle, data exchange, and teardown.

Split out from https://github.com/pion/transport/pull/375