### PR TITLE
New allocation-free replay detector API

### DIFF
--- a/replaydetector/replaydetector.go
+++ b/replaydetector/replaydetector.go
@@ -13,6 +13,52 @@ type ReplayDetector interface {
 	Check(seq uint64) (accept func() bool, ok bool)
 }
 
+// Token records the outcome of a replay check for one sequence number.
+// The zero value is inert: accepting it does nothing.
+type Token struct {
+	seq    uint64
+	passed bool
+}
+
+// Passed returns a Token recording that seq passed the replay check.
+func Passed(seq uint64) Token {
+	return Token{seq: seq, passed: true}
+}
+
+// Rejected returns an inert Token recording that seq failed the replay check.
+// Accepting the returned token is a no-op.
+func Rejected(seq uint64) Token {
+	return Token{seq: seq}
+}
+
+// Seq returns the sequence number the Token was created for.
+func (t Token) Seq() uint64 {
+	return t.seq
+}
+
+// Passed returns whether the sequence number passed the replay check.
+func (t Token) Passed() bool {
+	return t.passed
+}
+
+// CheckAccepter is a two-phase sequence replay detector: CheckSeq reports
+// whether a sequence number is acceptable, and Accept records it as seen.
+//
+// In a future major release, CheckAccepter will replace ReplayDetector.
+// ReplayDetectors returned by New and WithWrap also implement
+// CheckAccepter.
+type CheckAccepter interface {
+	// CheckSeq checks whether the given sequence number is not replayed and
+	// returns a Token recording the outcome. The token can be passed to
+	// Accept regardless of what the outcome of CheckSeq is.
+	CheckSeq(seq uint64) Token
+	// Accept marks a passed Token's sequence number as received properly.
+	// Accepting a rejected or zero-value Token does nothing and reports
+	// false. The return value indicates whether the packet was accepted and
+	// has the latest observed sequence number.
+	Accept(tok Token) (latest bool)
+}
+
 // nop is a no-op func that is returned in the case that Check() fails.
 func nop() bool {
 	return false
@@ -38,34 +84,62 @@ func New(windowSize uint, maxSeq uint64) ReplayDetector {
 }
 
 func (d *slidingWindowDetector) Check(seq uint64) (func() bool, bool) {
+	if !d.checkSeq(seq) {
+		return nop, false
+	}
+
+	return func() bool {
+		return d.acceptSeq(seq)
+	}, true
+}
+
+func (d *slidingWindowDetector) CheckSeq(seq uint64) Token {
+	if !d.checkSeq(seq) {
+		return Rejected(seq)
+	}
+
+	return Passed(seq)
+}
+
+func (d *slidingWindowDetector) Accept(tok Token) bool {
+	if !tok.Passed() {
+		return false
+	}
+
+	return d.acceptSeq(tok.Seq())
+}
+
+func (d *slidingWindowDetector) checkSeq(seq uint64) bool {
 	if seq > d.maxSeq {
 		// Exceeded upper limit.
-		return nop, false
+		return false
 	}
 
 	if seq <= d.latestSeq {
 		if d.latestSeq >= uint64(d.windowSize)+seq {
-			return nop, false
+			return false
 		}
 		if d.mask.Bit(uint(d.latestSeq-seq)) != 0 {
 			// The sequence number is duplicated.
-			return nop, false
+			return false
 		}
 	}
 
-	return func() bool {
-		latest := seq == 0
-		if seq > d.latestSeq {
-			// Update the head of the window.
-			d.mask.Lsh(uint(seq - d.latestSeq))
-			d.latestSeq = seq
-			latest = true
-		}
-		diff := (d.latestSeq - seq) % d.maxSeq
-		d.mask.SetBit(uint(diff))
+	return true
+}
 
-		return latest
-	}, true
+func (d *slidingWindowDetector) acceptSeq(seq uint64) bool {
+	latest := seq == 0
+	if seq > d.latestSeq {
+		// Update the head of the window.
+		d.mask.Lsh(uint(seq - d.latestSeq))
+		d.latestSeq = seq
+		latest = true
+	}
+	diff := (d.latestSeq - seq) % d.maxSeq
+	d.mask.SetBit(uint(diff))
+
+	return latest
 }
 
 // WithWrap creates ReplayDetector allowing sequence wrapping.
@@ -87,9 +161,42 @@ type wrappedSlidingWindowDetector struct {
 }
 
 func (d *wrappedSlidingWindowDetector) Check(seq uint64) (func() bool, bool) {
+	diff, ok := d.checkSeq(seq)
+	if !ok {
+		return nop, false
+	}
+
+	return func() bool {
+		// The closure reuses the check-time diff so that accepts invoked out of
+		// order behave exactly as Check's callers have historically observed,
+		// quirks included. Accept recomputes the diff at accept time instead.
+		return d.acceptDiff(seq, diff)
+	}, true
+}
+
+func (d *wrappedSlidingWindowDetector) CheckSeq(seq uint64) Token {
+	if _, ok := d.checkSeq(seq); !ok {
+		return Rejected(seq)
+	}
+
+	return Passed(seq)
+}
+
+func (d *wrappedSlidingWindowDetector) Accept(tok Token) bool {
+	if !tok.Passed() {
+		return false
+	}
+
+	// NOTE: Recompute diff at accept time (rather than storing on the token)
+	// so that it's computed from the correct latestSeq in case accepts are
+	// called out of order.
+	return d.acceptDiff(tok.Seq(), d.diff(tok.Seq()))
+}
+
+func (d *wrappedSlidingWindowDetector) checkSeq(seq uint64) (int64, bool) {
 	if seq > d.maxSeq {
 		// Exceeded upper limit.
-		return nop, false
+		return 0, false
 	}
 	if !d.init {
 		if seq != 0 {
@@ -100,6 +207,40 @@ func (d *wrappedSlidingWindowDetector) Check(seq uint64) (func() bool, bool) {
 		d.init = true
 	}
 
+	diff := d.diff(seq)
+
+	if diff >= int64(d.windowSize) { //nolint:gosec // GG115 TODO check
+		// Too old.
+		return diff, false
+	}
+	if diff >= 0 {
+		if d.mask.Bit(uint(diff)) != 0 {
+			// The sequence number is duplicated.
+			return diff, false
+		}
+	}
+
+	return diff, true
+}
+
+func (d *wrappedSlidingWindowDetector) acceptDiff(seq uint64, diff int64) bool {
+	if diff < 0 {
+		// Update the head of the window.
+		d.mask.Lsh(uint(-diff))
+		d.latestSeq = seq
+		d.mask.SetBit(0)
+
+		return true
+	}
+	d.mask.SetBit(uint(diff))
+
+	return false
+}
+
+// diff returns the distance of seq behind the latest observed sequence
+// number, wrapped around maxSeq to the shorter direction (negative means
+// seq is ahead of the window head).
+func (d *wrappedSlidingWindowDetector) diff(seq uint64) int64 {
 	diff := int64(d.latestSeq) - int64(seq) //nolint:gosec // GG115 TODO check
 	// Wrap the number.
 	if diff > int64(d.maxSeq)/2 { //nolint:gosec // GG115 TODO check
@@ -108,29 +249,5 @@ func (d *wrappedSlidingWindowDetector) Check(seq uint64) (func() bool, bool) {
 		diff += int64(d.maxSeq + 1) //nolint:gosec // GG115 TODO check
 	}
 
-	if diff >= int64(d.windowSize) { //nolint:gosec // GG115 TODO check
-		// Too old.
-		return nop, false
-	}
-	if diff >= 0 {
-		if d.mask.Bit(uint(diff)) != 0 {
-			// The sequence number is duplicated.
-			return nop, false
-		}
-	}
-
-	return func() bool {
-		latest := false
-		if diff < 0 {
-			// Update the head of the window.
-			d.mask.Lsh(uint(-diff))
-			d.latestSeq = seq
-			latest = true
-			d.mask.SetBit(0)
-		} else {
-			d.mask.SetBit(uint(diff))
-		}
-
-		return latest
-	}, true
+	return diff
 }

--- a/replaydetector/replaydetector_test.go
+++ b/replaydetector/replaydetector_test.go
@@ -23,6 +23,11 @@ const (
 	hugeSeq  = 0x1000000000000
 )
 
+var (
+	_ CheckAccepter = (*slidingWindowDetector)(nil)
+	_ CheckAccepter = (*wrappedSlidingWindowDetector)(nil)
+)
+
 var commonCases = map[string]testCase{ //nolint:gochecknoglobals
 	"Continuous": {
 		16, 0x0000FFFFFFFFFFFF,
@@ -189,20 +194,50 @@ var commonCases = map[string]testCase{ //nolint:gochecknoglobals
 	},
 }
 
+func runCheckCase(t *testing.T, det ReplayDetector, tc testCase) {
+	t.Helper()
+
+	var out []uint64
+	for i, seq := range tc.input {
+		accept, ok := det.Check(seq)
+		assert.Equal(t, tc.valid[i], ok, "Unexpected validity")
+		if ok {
+			out = append(out, seq)
+		}
+		assert.Equal(t, tc.latest[i], accept(), "Unexpected sequence latest status")
+	}
+	assert.Equal(t, tc.expected, out, "Wrong replay detection result")
+}
+
+func runCheckAccepterCase(t *testing.T, det ReplayDetector, tc testCase) {
+	t.Helper()
+
+	ca, ok := det.(CheckAccepter)
+	assert.True(t, ok, "detector must implement CheckAccepter")
+
+	var out []uint64
+	for i, seq := range tc.input {
+		tok := ca.CheckSeq(seq)
+		assert.Equal(t, tc.valid[i], tok.Passed(), "Unexpected validity")
+		if tok.Passed() {
+			out = append(out, seq)
+		}
+		assert.Equal(t, tc.latest[i], ca.Accept(tok), "Unexpected sequence latest status")
+	}
+	assert.Equal(t, tc.expected, out, "Wrong replay detection result")
+}
+
 func TestReplayDetector(t *testing.T) {
-	for name, testCase := range commonCases {
-		t.Run(name, func(t *testing.T) {
-			det := New(testCase.windowSize, testCase.maxSeq)
-			var out []uint64
-			for i, seq := range testCase.input {
-				accept, ok := det.Check(seq)
-				assert.Equal(t, testCase.valid[i], ok, "Unexpected validity")
-				if ok {
-					out = append(out, seq)
-				}
-				assert.Equal(t, testCase.latest[i], accept(), "Unexpected sequence latest status")
+	for apiName, runCase := range map[string]func(*testing.T, ReplayDetector, testCase){
+		"Check":         runCheckCase,
+		"CheckAccepter": runCheckAccepterCase,
+	} {
+		t.Run(apiName, func(t *testing.T) {
+			for name, tc := range commonCases {
+				t.Run(name, func(t *testing.T) {
+					runCase(t, New(tc.windowSize, tc.maxSeq), tc)
+				})
 			}
-			assert.Equal(t, testCase.expected, out, "Wrong replay detection result")
 		})
 	}
 }
@@ -259,20 +294,89 @@ func TestReplayDetectorWrapped(t *testing.T) {
 		assert.False(t, ok, "Duplicate test case name: %q", name)
 		cases[name] = c
 	}
-	for name, c := range cases {
-		testCase := c
-		t.Run(name, func(t *testing.T) {
-			det := WithWrap(testCase.windowSize, testCase.maxSeq)
-			var out []uint64
-			for i, seq := range testCase.input {
-				accept, ok := det.Check(seq)
-				assert.Equal(t, testCase.valid[i], ok, "Unexpected validity")
-				if ok {
-					out = append(out, seq)
-				}
-				assert.Equal(t, testCase.latest[i], accept(), "Unexpected sequence latest status")
+
+	for apiName, runCase := range map[string]func(*testing.T, ReplayDetector, testCase){
+		"Check":         runCheckCase,
+		"CheckAccepter": runCheckAccepterCase,
+	} {
+		t.Run(apiName, func(t *testing.T) {
+			for name, tc := range cases {
+				t.Run(name, func(t *testing.T) {
+					runCase(t, WithWrap(tc.windowSize, tc.maxSeq), tc)
+				})
 			}
-			assert.Equal(t, testCase.expected, out, "Wrong replay detection result")
+		})
+	}
+}
+
+// TestCheckSeqDoesNotCommit verifies that CheckSeq alone does not update the
+// replay list: RFC 3711 Section 3.3.2 requires the list to be updated only
+// after the packet has been authenticated, so a sequence number that passed
+// CheckSeq but was never accepted must still pass a later check.
+func TestCheckSeqDoesNotCommit(t *testing.T) {
+	kinds := map[string]ReplayDetector{
+		"New":      New(16, 0xFFFF),
+		"WithWrap": WithWrap(16, 0xFFFF),
+	}
+
+	for name, detector := range kinds {
+		t.Run(name, func(t *testing.T) {
+			det, ok := detector.(CheckAccepter)
+			assert.True(t, ok, "detector must implement CheckAccepter")
+
+			assert.True(t, det.CheckSeq(5).Passed(), "first check must pass")
+			tok := det.CheckSeq(5)
+			assert.True(t, tok.Passed(), "re-check of an unaccepted seq must pass")
+			det.Accept(tok)
+			assert.False(t, det.CheckSeq(5).Passed(), "check after accept must reject the duplicate")
+		})
+	}
+}
+
+// TestRejectedTokenIsInert verifies that accepting a rejected or zero-value
+// Token does not modify the window: a sequence number that failed its check
+// cannot corrupt the detector even if its Token is accepted.
+func TestRejectedTokenIsInert(t *testing.T) {
+	kinds := map[string]ReplayDetector{
+		"New":      New(16, 0xFFFF),
+		"WithWrap": WithWrap(16, 0xFFFF),
+	}
+
+	for name, detector := range kinds {
+		t.Run(name, func(t *testing.T) {
+			det, ok := detector.(CheckAccepter)
+			assert.True(t, ok, "detector must implement CheckAccepter")
+
+			rejected := det.CheckSeq(0x10000) // beyond maxSeq
+			assert.False(t, rejected.Passed(), "out-of-range seq must fail the check")
+			assert.False(t, det.Accept(rejected), "accepting a rejected token must do nothing")
+			assert.False(t, det.Accept(Token{}), "accepting a zero-value token must do nothing")
+
+			tok := det.CheckSeq(5)
+			assert.True(t, tok.Passed(), "window must be intact after inert accepts")
+			det.Accept(tok)
+			assert.False(t, det.CheckSeq(5).Passed(), "duplicate must still be rejected after inert accepts")
+		})
+	}
+}
+
+func TestCheckAccepterNoAllocation(t *testing.T) {
+	kinds := map[string]ReplayDetector{
+		"New":      New(128, 0x0000FFFFFFFFFFFF),
+		"WithWrap": WithWrap(128, 0xFFFF),
+	}
+
+	for name, detector := range kinds {
+		t.Run(name, func(t *testing.T) {
+			det, ok := detector.(CheckAccepter)
+			assert.True(t, ok, "detector must implement CheckAccepter")
+
+			seq := uint64(0)
+			allocs := testing.AllocsPerRun(1000, func() {
+				seq++
+				det.Accept(det.CheckSeq(seq))
+			})
+			assert.Zero(t, allocs, "CheckSeq/Accept must not allocate")
 		})
 	}
 }


### PR DESCRIPTION
The current `replaydetector.ReplayDetector` API allocates for each inbound packet in order to create and return the closure to accept the packet. In order to avoid this allocation, a new two-phase API is introduced that has separate check and accept methods.

The detectors returned by `New` and `WithWrap` implement both the new and legacy APIs. The behavior of the legacy API is unchanged. The new API differs for the wrapped variant with regard to out-of-order accepts; the legacy API could end up erroneously accepting a replayed packet in this case while the new API will not.

The new API uses a "token" to pass to accept (as opposed to, e.g., having Accept take a sequence number) in order to allow the same no-op on rejected packets pattern that the legacy API supported. Factory methods for creating accepted and rejected tokens exist to allow users to create custom replay detectors while making it difficult (or at least obvious) to misuse the API.