### PR TITLE
Add Deadline.Context for derived contexts

### DIFF
--- a/deadline/deadline.go
+++ b/deadline/deadline.go
@@ -14,10 +14,19 @@ import (
 type deadlineState uint8
 
 const (
-	deadlineStopped deadlineState = iota
+	deadlineSuspended deadlineState = iota
 	deadlineStarted
 	deadlineExceeded
 )
+
+//nolint:gochecknoglobals // A canceled context is immutable, so it is safe to share.
+var exceededContext context.Context
+
+func init() {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(context.DeadlineExceeded)
+	exceededContext = ctx
+}
 
 var _ context.Context = (*Deadline)(nil)
 
@@ -75,6 +84,10 @@ func (d *Deadline) fire() context.CancelCauseFunc {
 func (d *Deadline) Context() context.Context {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+
+	if d.state == deadlineExceeded {
+		return exceededContext
+	}
 	if d.ctx == nil {
 		d.ctx, d.cancel = context.WithCancelCause(context.Background())
 	}
@@ -106,7 +119,7 @@ func (d *Deadline) set(setTo time.Time) context.CancelCauseFunc {
 
 	if setTo.IsZero() {
 		d.pending--
-		d.state = deadlineStopped
+		d.state = deadlineSuspended
 
 		return nil
 	}

--- a/deadline/deadline.go
+++ b/deadline/deadline.go
@@ -24,9 +24,12 @@ var _ context.Context = (*Deadline)(nil)
 // Deadline signals updatable deadline timer.
 // Also, it implements context.Context.
 type Deadline struct {
-	mu       sync.RWMutex
-	timer    timer
-	done     chan struct{}
+	mu     sync.RWMutex
+	timer  timer
+	done   chan struct{}
+	ctx    context.Context //nolint:containedctx // Deadline state, not a request scope.
+	cancel context.CancelCauseFunc
+
 	deadline time.Time
 	state    deadlineState
 	pending  uint8
@@ -47,15 +50,46 @@ func (d *Deadline) timeout() {
 		return
 	}
 
-	d.state = deadlineExceeded
-	done := d.done
+	cancel := d.fire()
 	d.mu.Unlock()
 
-	close(done)
+	if cancel != nil {
+		cancel(context.DeadlineExceeded)
+	}
+}
+
+// Returns the cancel func rather than calling it: canceling walks derived
+// contexts' closures, which must not run under mu.
+func (d *Deadline) fire() context.CancelCauseFunc {
+	d.state = deadlineExceeded
+	close(d.done)
+
+	cancel := d.cancel
+	d.ctx, d.cancel = nil, nil
+
+	return cancel
+}
+
+// Context returns a context for the current deadline, canceled with
+// context.DeadlineExceeded as its Cause.
+func (d *Deadline) Context() context.Context {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.ctx == nil {
+		d.ctx, d.cancel = context.WithCancelCause(context.Background())
+	}
+
+	return d.ctx
 }
 
 // Set new deadline. Zero value means no deadline.
 func (d *Deadline) Set(setTo time.Time) {
+	if cancel := d.set(setTo); cancel != nil {
+		cancel(context.DeadlineExceeded)
+	}
+}
+
+func (d *Deadline) set(setTo time.Time) context.CancelCauseFunc {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -74,7 +108,7 @@ func (d *Deadline) Set(setTo time.Time) {
 		d.pending--
 		d.state = deadlineStopped
 
-		return
+		return nil
 	}
 
 	if dur := time.Until(setTo); dur > 0 {
@@ -85,12 +119,12 @@ func (d *Deadline) Set(setTo time.Time) {
 			d.timer.Reset(dur)
 		}
 
-		return
+		return nil
 	}
 
 	d.pending--
-	d.state = deadlineExceeded
-	close(d.done)
+
+	return d.fire()
 }
 
 // Done receives deadline signal.

--- a/deadline/deadline_test.go
+++ b/deadline/deadline_test.go
@@ -212,15 +212,50 @@ func TestDeadlineContext(t *testing.T) {
 		assertCanceled(t, ctx, context.DeadlineExceeded)
 	})
 
-	t.Run("StopKeepsContextLive", func(t *testing.T) {
+	t.Run("SuspendKeepsContextLive", func(t *testing.T) {
 		d := New()
 		d.Set(time.Now().Add(time.Hour))
 		ctx := d.Context()
 
 		d.Set(time.Time{}) // no deadline
 
-		assert.Equal(t, ctx, d.Context(), "Stopping the deadline should not retire the context")
+		assert.Equal(t, ctx, d.Context(), "Suspending the deadline should not retire the context")
 		assertLive(t, ctx)
+	})
+
+	t.Run("ExceededReturnsCanceledContext", func(t *testing.T) {
+		d := New()
+		d.Set(time.Unix(0, 1))
+
+		assertCanceled(t, d.Context(), context.DeadlineExceeded)
+	})
+
+	t.Run("ExceededByTimerReturnsCanceledContext", func(t *testing.T) {
+		d := New()
+		d.Set(time.Now().Add(10 * time.Millisecond))
+		assertCanceled(t, d.Context(), context.DeadlineExceeded)
+
+		assertCanceled(t, d.Context(), context.DeadlineExceeded)
+	})
+
+	t.Run("DerivedFromExceededIsCanceled", func(t *testing.T) {
+		d := New()
+		d.Set(time.Unix(0, 1))
+
+		derived, cancel := context.WithCancel(d.Context())
+		defer cancel()
+
+		assertCanceled(t, derived, context.DeadlineExceeded)
+	})
+
+	t.Run("SuspendAfterExpiryGivesLiveContext", func(t *testing.T) {
+		d := New()
+		d.Set(time.Unix(0, 1))
+		assertCanceled(t, d.Context(), context.DeadlineExceeded)
+
+		d.Set(time.Time{}) // no deadline
+
+		assertLive(t, d.Context())
 	})
 
 	t.Run("NewGenerationAfterExpiry", func(t *testing.T) {

--- a/deadline/deadline_test.go
+++ b/deadline/deadline_test.go
@@ -5,6 +5,8 @@ package deadline
 
 import (
 	"context"
+	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -149,6 +151,148 @@ func TestContext(t *testing.T) { //nolint:cyclop
 		t1, expired1 := d.Deadline()
 		assert.True(t, t1.Equal(dl), "Initial Deadline is expected to be %v, got %v", dl, t1)
 		assert.True(t, expired1, "Deadline is expected to be expired")
+	})
+}
+
+func assertCanceled(t *testing.T, ctx context.Context, cause error) {
+	t.Helper()
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		assert.Fail(t, "context was not canceled")
+
+		return
+	}
+	assert.ErrorIs(t, context.Cause(ctx), cause)
+}
+
+func assertLive(t *testing.T, ctx context.Context) {
+	t.Helper()
+
+	select {
+	case <-ctx.Done():
+		assert.Fail(t, "context was unexpectedly canceled")
+	default:
+	}
+	assert.NoError(t, ctx.Err())
+}
+
+func TestDeadlineContext(t *testing.T) {
+	t.Run("MemoizedAcrossCalls", func(t *testing.T) {
+		d := New()
+		d.Set(time.Now().Add(time.Hour))
+
+		assert.Equal(t, d.Context(), d.Context(), "Context should be memoized")
+	})
+
+	t.Run("ExtendKeepsSameContext", func(t *testing.T) {
+		d := New()
+		d.Set(time.Now().Add(time.Hour))
+		ctx := d.Context()
+
+		d.Set(time.Now().Add(2 * time.Hour))
+
+		assert.Equal(t, ctx, d.Context(), "Extending the deadline should not retire the context")
+		assertLive(t, ctx)
+	})
+
+	t.Run("CanceledByTimer", func(t *testing.T) {
+		d := New()
+		d.Set(time.Now().Add(10 * time.Millisecond))
+
+		assertCanceled(t, d.Context(), context.DeadlineExceeded)
+	})
+
+	t.Run("CanceledByPastDeadline", func(t *testing.T) {
+		d := New()
+		ctx := d.Context()
+		d.Set(time.Unix(0, 1))
+
+		assertCanceled(t, ctx, context.DeadlineExceeded)
+	})
+
+	t.Run("StopKeepsContextLive", func(t *testing.T) {
+		d := New()
+		d.Set(time.Now().Add(time.Hour))
+		ctx := d.Context()
+
+		d.Set(time.Time{}) // no deadline
+
+		assert.Equal(t, ctx, d.Context(), "Stopping the deadline should not retire the context")
+		assertLive(t, ctx)
+	})
+
+	t.Run("NewGenerationAfterExpiry", func(t *testing.T) {
+		d := New()
+		expired := d.Context()
+		d.Set(time.Unix(0, 1))
+		assertCanceled(t, expired, context.DeadlineExceeded)
+
+		d.Set(time.Now().Add(time.Hour))
+		revived := d.Context()
+
+		assert.NotEqual(t, expired, revived, "Reviving the deadline should mint a new context")
+		assertLive(t, revived)
+		assertCanceled(t, expired, context.DeadlineExceeded)
+	})
+
+	t.Run("DerivedContextIsCanceled", func(t *testing.T) {
+		d := New()
+		d.Set(time.Now().Add(10 * time.Millisecond))
+
+		derived, cancel := context.WithCancel(d.Context())
+		defer cancel()
+
+		assertCanceled(t, derived, context.DeadlineExceeded)
+	})
+
+	t.Run("DerivedContextsDoNotSpawnGoroutines", func(t *testing.T) {
+		const derived = 100
+
+		d := New()
+		d.Set(time.Now().Add(time.Hour))
+		parent := d.Context()
+
+		runtime.GC()
+		before := runtime.NumGoroutine()
+
+		cancels := make([]context.CancelFunc, 0, derived)
+		for range derived {
+			_, cancel := context.WithCancel(parent)
+			cancels = append(cancels, cancel)
+		}
+		spawned := runtime.NumGoroutine() - before
+		for _, cancel := range cancels {
+			cancel()
+		}
+
+		// A *cancelCtx parent registers children in a map; anything else costs
+		// a goroutine per child.
+		assert.Less(t, spawned, derived/10, "Deriving contexts should not spawn goroutines")
+	})
+
+	t.Run("ConcurrentContextAndSet", func(t *testing.T) {
+		deadline := New()
+
+		var wg sync.WaitGroup
+		for range 8 {
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				for range 500 {
+					_ = deadline.Context().Err()
+				}
+			}()
+			go func() {
+				defer wg.Done()
+				for range 500 {
+					deadline.Set(time.Unix(0, 1))
+					deadline.Set(time.Now().Add(time.Hour))
+				}
+			}()
+		}
+		wg.Wait()
 	})
 }
 


### PR DESCRIPTION
`deadline.Deadline` is revivable via `Set`, so it is not monotonic, and `context.Context` requires that it be:

> If Done is not yet closed, Err returns nil.
> If Done is closed, Err returns a non-nil error explaining why.
> After Err returns a non-nil error, successive calls to Err return the same error.

After a `Deadline` expires and is set again, `Err()` goes from `DeadlineExceeded` back to `nil` and `Done()` hands out a fresh open channel while earlier holders still see the old one closed — two observers of the same "context" disagreeing permanently.

That makes deriving a context from a `Deadline` unsafe. Both propagation paths in `context` read `parent.Err()` *after* observing `Done`:

```go
case <-parent.Done():
    child.cancel(false, parent.Err(), Cause(parent))
```

and `cancelCtx.cancel` panics on a nil error, before its already-cancelled early return. A `Set` landing in that window panics inside the standard library:

```
panic: context: internal error: missing cancel error
  context.(*cancelCtx).cancel(...)              context/context.go:552
  context.(*cancelCtx).propagateCancel.func2()  context/context.go:526
```

This reproduces on `main` today with no callback API in the tree.

### This PR

`Context()` returns a real cancel context scoped to the current deadline generation, so what callers hold is monotonic even though `Deadline` is not:

- memoized while the deadline is live — extending it keeps the same context
- cancelled when the deadline fires, with `context.DeadlineExceeded` as its `context.Cause`
- replaced on the next call after expiry, so a retired context stays cancelled forever

Because the returned value is a `*cancelCtx`, `parentCancelCtx` finds it and children register in its map — deriving 100 contexts spawns **0** goroutines, versus one watchdog goroutine per child for any parent `context` cannot recognise.

`timeout` and `Set` now share a `fire` helper, which also closes `done` inside the critical section and removes the pre-existing window where `Err()` reported `DeadlineExceeded` while `Done()` was still open.

Purely additive — `Set`, `Done`, `Err` and `Deadline` are untouched and the `context.Context` implementation is left in place. #398 removes that separately.

### Testing

`TestDeadlineContext` covers memoization, extend, stop, timer and past-deadline expiry, generation replacement with the retired context staying cancelled, derived-context cancellation, the zero-goroutine property, and concurrent `Context`/`Set`. Green under `-race`.


